### PR TITLE
Simpler peakfinding: just per-channel peakfinding

### DIFF
--- a/pax/config/XENON100.ini
+++ b/pax/config/XENON100.ini
@@ -9,16 +9,7 @@ parent_configuration = "_base"
 
 dsp = [
        'BuildWaveforms.BuildWaveforms',
-
-       'Filtering.Filtering',
-
-       'BigPeakfinder.FindBigPeaks',
-
-       'BigPeakProcessing.ComputePeakAreasAndCoincidence',
-       'BigPeakProcessing.ComputePeakWidths',
-       #'BigPeakProcessing.ComputePeakEntropies',
-       'BigPeakProcessing.ClassifyBigPeaks',
-       'BigPeakProcessing.DeleteSmallPeaks',
+       'Filtering.Filtering',   # Just for fun, looks nice in plot
 
        'SmallPeakfinder.FindSmallPeaks',
 
@@ -45,93 +36,6 @@ filters = (
         )},
     )
 
-
-[BigPeakfinder.FindBigPeaks]
-# High-statistics peakfinding
-peakfinders = [
-        {
-            'peakfinding_wave'          : 'tpc_s2',
-            'unfiltered_wave'           : 'tpc',
-            # Find peaks only if peakfinding_wave exceeds the following threshold:
-            'threshold'                 : 0.15, # pe/bin
-            # For at least this many samples:
-            'min_interval_width'        : 30, #samples
-            # Try to split the peak into subpeaks if the interval is wider than this many samples:
-            'min_split_attempt_width'   : 120, #samples
-            # Splitting is done by looking for local maxima ('peaks') and minima ('valleys')
-            # If one or no peaks/valley pairs are found, the peak is not split.
-            # To eliminate wiggle, cut peaks and valleys intelligently (keep ones with high p/v ratio)
-            # until remainin peak/valley pairs satisfy the criteria below:
-            'min_p_v_ratio'             : 2,
-            'min_p_v_distance'          : 30, #samples
-            'min_p_v_difference'        : 0.5, #pe/bin
-        },
-        {
-            'peakfinding_wave'          : 'tpc_s1',
-            'unfiltered_wave'           : 'tpc',
-            'threshold'                 : 0.15, # pe/bin
-            'peak_integration_bound'    : 0.01, # of maximum,
-        },
-        {
-            'peakfinding_wave'          : 'veto_s1',
-            'area_threshold'            : 20, # pe/bin
-            'unfiltered_wave'           : 'veto',
-            'threshold'                 : 0.15,  # pe/bin
-            'peak_integration_bound'    : 0.01, # of maximum
-        },
-    ]
-
-derivative_kernel = [-0.003059, -0.035187, -0.118739, -0.143928, 0.000000, 0.143928, 0.118739, 0.035187, 0.003059]
-
-[BigPeakProcessing.ClassifyBigPeaks]
-central_area_ratio = 0.5  #If central_area >= this number * area, it is an S1
-
-
-[BigPeakProcessing.ComputePeakAreasAndCoincidence]
-# A channel counts as 'contributing' if its area within the peak bounds is >= than:
-# Note the area is higher than usual (0.35pe), this is for high-energy peaks only
-minimum_area = 0.35 #pe
-
-# Width of the central region used in S1/S2 identification
-central_area_region_width = 50 * ns
-
-
-[BigPeakProcessing.ComputePeakEntropies]
-normalization_mode = 'square'       # How to convert the signal to positive values: square or abs
-
-
-[BigPeakProcessing.ComputePeakWidths]
-width_computations = {
-    'full_width_half_max' : {
-        'waveform_to_use' : 'tpc',
-        'fraction_of_max' : 0.5,
-        'interpolate' :     True,
-    },
-    'full_width_tenth_max' : {
-        'waveform_to_use' : 'tpc',
-        'fraction_of_max' : 0.1,
-        'interpolate' :     True,
-    },
-    'full_width_half_max_filtered' : {
-        'waveform_to_use' : 'tpc_s2',
-        'fraction_of_max' : 0.5,
-        'interpolate' :     True,
-    },
-    'full_width_tenth_max_filtered' : {
-        'waveform_to_use' : 'tpc_s2',
-        'fraction_of_max' : 0.1,
-        'interpolate' :     True,
-    }
-  }
-
-
-[BigPeakProcessing.DeleteSmallPeaks]
-# Deletes low coincidence peaks, so the low-energy peakfinder can have a crack at them
-prune_if_coincidence_lower_than = 7 #contributing PMTs
-# Also delete low-area peaks
-# Setting this from 100->1000 increased runtime of this plugin by about 50%
-# ... it also appears the ad-hoc MAD classification fails on higher peaks... so keep this low.
-prune_if_area_lower_than = 100 #pe
 
 
 [SmallPeakfinder.FindSmallPeaks]

--- a/pax/config/two_step_peakfinding.ini
+++ b/pax/config/two_step_peakfinding.ini
@@ -1,0 +1,110 @@
+# This is just for setting up pax
+[pax]
+parent_configuration = "XENON100"
+
+dsp = [
+       'BuildWaveforms.BuildWaveforms',
+
+       'Filtering.Filtering',
+
+       'BigPeakfinder.FindBigPeaks',
+
+       'BigPeakProcessing.ComputePeakAreasAndCoincidence',
+       'BigPeakProcessing.ComputePeakWidths',
+       #'BigPeakProcessing.ComputePeakEntropies',
+       'BigPeakProcessing.ClassifyBigPeaks',
+       'BigPeakProcessing.DeleteSmallPeaks',
+
+       'SmallPeakfinder.FindSmallPeaks',
+
+       'SmallPeakProcessing.ClusterSmallPeaks',
+       'SmallPeakProcessing.AdHocClassification',
+
+       ]
+
+[BigPeakfinder.FindBigPeaks]
+# High-statistics peakfinding
+peakfinders = [
+        {
+            'peakfinding_wave'          : 'tpc_s2',
+            'unfiltered_wave'           : 'tpc',
+            # Find peaks only if peakfinding_wave exceeds the following threshold:
+            'threshold'                 : 0.15, # pe/bin
+            # For at least this many samples:
+            'min_interval_width'        : 30, #samples
+            # Try to split the peak into subpeaks if the interval is wider than this many samples:
+            'min_split_attempt_width'   : 120, #samples
+            # Splitting is done by looking for local maxima ('peaks') and minima ('valleys')
+            # If one or no peaks/valley pairs are found, the peak is not split.
+            # To eliminate wiggle, cut peaks and valleys intelligently (keep ones with high p/v ratio)
+            # until remainin peak/valley pairs satisfy the criteria below:
+            'min_p_v_ratio'             : 2,
+            'min_p_v_distance'          : 30, #samples
+            'min_p_v_difference'        : 0.5, #pe/bin
+        },
+        {
+            'peakfinding_wave'          : 'tpc_s1',
+            'unfiltered_wave'           : 'tpc',
+            'threshold'                 : 0.15, # pe/bin
+            'peak_integration_bound'    : 0.01, # of maximum,
+        },
+        {
+            'peakfinding_wave'          : 'veto_s1',
+            'area_threshold'            : 20, # pe/bin
+            'unfiltered_wave'           : 'veto',
+            'threshold'                 : 0.15,  # pe/bin
+            'peak_integration_bound'    : 0.01, # of maximum
+        },
+    ]
+
+derivative_kernel = [-0.003059, -0.035187, -0.118739, -0.143928, 0.000000, 0.143928, 0.118739, 0.035187, 0.003059]
+
+[BigPeakProcessing.ClassifyBigPeaks]
+central_area_ratio = 0.5  #If central_area >= this number * area, it is an S1
+
+
+[BigPeakProcessing.ComputePeakAreasAndCoincidence]
+# A channel counts as 'contributing' if its area within the peak bounds is >= than:
+# Note the area is higher than usual (0.35pe), this is for high-energy peaks only
+minimum_area = 0.35 #pe
+
+# Width of the central region used in S1/S2 identification
+central_area_region_width = 50 * ns
+
+
+[BigPeakProcessing.ComputePeakEntropies]
+normalization_mode = 'square'       # How to convert the signal to positive values: square or abs
+
+
+[BigPeakProcessing.ComputePeakWidths]
+width_computations = {
+    'full_width_half_max' : {
+        'waveform_to_use' : 'tpc',
+        'fraction_of_max' : 0.5,
+        'interpolate' :     True,
+    },
+    'full_width_tenth_max' : {
+        'waveform_to_use' : 'tpc',
+        'fraction_of_max' : 0.1,
+        'interpolate' :     True,
+    },
+    'full_width_half_max_filtered' : {
+        'waveform_to_use' : 'tpc_s2',
+        'fraction_of_max' : 0.5,
+        'interpolate' :     True,
+    },
+    'full_width_tenth_max_filtered' : {
+        'waveform_to_use' : 'tpc_s2',
+        'fraction_of_max' : 0.1,
+        'interpolate' :     True,
+    }
+  }
+
+
+[BigPeakProcessing.DeleteSmallPeaks]
+# Deletes low coincidence peaks, so the low-energy peakfinder can have a crack at them
+prune_if_coincidence_lower_than = 7 #contributing PMTs
+# Also delete low-area peaks
+# Setting this from 100->1000 increased runtime of this plugin by about 50%
+# ... it also appears the ad-hoc MAD classification fails on higher peaks... so keep this low.
+prune_if_area_lower_than = 100 #pe


### PR DESCRIPTION
Currently two peakfinders run over our data: FindBigPeaks, which uses the sum waveform, and FindSmallPeaks, which looks in every channel separately. FindSmallPeaks skips regions where FindBigPeaks has found a large enough peak. 

The reason for this somewhat convoluted setup was speed: using FindSmallPeaks was 3x slower. However, this speedup comes at a price:
- **Artefacts**. FindBigPeaks sometimes hacks the 'toes' off a peak because the (filtered) sum waveform crosses 0. The loose toes are found by FindSmallPeaks and reported as a new peak... of who knows what type. Smarter clustering of channel peaks won't resolve this, as no channel peaks are searched for in a big peak.
- Switching between two peakfinders in the middle of our analysis range may make determination of efficiency and acceptances more complex: we'd have discontinuities.
- Classification and splitting/clustering routines have to be written twice, since a sum waveform peakfinder gives other variables than a per-channel peakfinder (e.g. half-maximum pulse width vs standard deviation of per-channel peaks)
- In general there's a lot more code to maintain: essentially two parallel signal processing chains.

Now that I've done some basic optimizations (already in master, mostly redundant sorts and list comprehensions) and tried out numba (separate pull request) the performance hit from doing 1pe peakfinding everywhere is no longer so great. On my home system, with the standard XED file, I get:

**Double peakfinding**
    Before optimizations:       3.9 Hz
    After python optimizations: 4.2 Hz
    After numba:                4.7 Hz

**Per-channel peakfinding only**
    Before optimizations:       1.3 Hz
    After python optimizations: 2.0 Hz
    After numba:                2.6 Hz

We can probably gain some more performance by switching off type checking in the datatstructure during production runs, and we're just getting started with numba. 

I'd say speed no longer justifies keeping double peakfinding in light of the problems mentioned above.

This pull request changes no code: it only removes the old double peakfinding settings from the default Xenon100 ini (it remains available in `two_step_peakfinding.ini`). We can delete the old sum-waveform peakfinding code later, if we want.
