### PR TITLE
Clean exit

### DIFF
--- a/bin/paxer
+++ b/bin/paxer
@@ -115,7 +115,7 @@ pax_instance = core.Processor(
 try:
     pax_instance.run()
 except (KeyboardInterrupt, SystemExit):
-    print("Shutting down all plugins...")
+    print("\nShutting down all plugins...")
     pax_instance.stop()
     print("Exiting")
     sys.exit()

--- a/pax/core.py
+++ b/pax/core.py
@@ -501,6 +501,7 @@ class Processor:
 
         # Shutdown all plugins now -- don't wait until this Processor instance gets deleted
         if clean_shutdown:
+            self.log.debug("Shutting down all plugins...")
             self.stop()
 
     # Call shutdown on all plugins


### PR DESCRIPTION
When interrupting a running pax (via SIGINT, Ctrl-C) it shuts down all plugins first and exits cleanly.

This involves only a minor modification, but since it affects 'core' and 'paxer' I've created this pull request.
