### PR TITLE
Restore clustering  code

### DIFF
--- a/pax/plugins/signal_processing/Cluster.py
+++ b/pax/plugins/signal_processing/Cluster.py
@@ -318,9 +318,9 @@ class GapSize(ClusterPlugin):
             area += hit.area
 
             # Can we start applying the tighter threshold?
-            # if area > self.transition_point:
-            #     # Yes, there's no chance this is a single electron: use a tighter clustering boundary
-            #     gap_size_threshold = self.small_gap_threshold
+            if area > self.transition_point:
+                # Yes, there's no chance this is a single electron: use a tighter clustering boundary
+                gap_size_threshold = self.small_gap_threshold
 
             # Extend the boundary at which a new clusters starts, if needed
             boundary = max(boundary, hit.right + gap_size_threshold)


### PR DESCRIPTION
It seems pax's clustering efficiency has gone down recently. While looking at cluster.py, I noticed some code in the default clustering algorithm was commented out in 1a60e3f685993de19e11392ec3cb992e097c7735:

```
        # Can we start applying the tighter threshold?
        # if area > self.transition_point:
        #     # Yes, there's no chance this is a single electron: use a tighter clustering boundary
        #     gap_size_threshold = self.small_gap_threshold
```

Besides this, that commit contains only Muenster-TPC specific stuff, so it was almost certainly accidental. The effect is that the gap size clustering now attacks everything with settings appropriate only for single-electron S2s. In particular, S1 declustering will be hurt by this, although pax probably won't be very good at that with the current settings even after this fix (see also #181).

@xolotl90, if you would like to disable the gap size threshold transition point for your gaseous measurement, I would recomment you set `transition_point = float('inf')` in your measurement's configuration file. 

@tunnell, could you make a patch release after this is merged? I''ll think about some way to run pftest + automated summary regularly to check for things like these, which could happen to any of us.
