### PR TITLE
Natural break declustering

### DIFF
--- a/pax/config/XENON100.ini
+++ b/pax/config/XENON100.ini
@@ -120,8 +120,6 @@ small_gap_threshold = 100 * ns
 
 
 [Cluster.NaturalBreaks]
-#TODO: weigh hits by area!
-
 # Always break if a gap of this size is encountered
 max_gap_size_in_cluster = 600 * ns
 
@@ -129,6 +127,7 @@ max_gap_size_in_cluster = 600 * ns
 min_split_goodness = 'lambda n : max(0.1, 1.2 - 1.1/150 * n)'
 
 # Limit gaps to test for performance reasons
+# Haven't tested if these are actually harmful, needed, or effective...
 min_gap_size_for_break = 50 * ns
 max_n_gaps_to_test = float('inf')
 


### PR DESCRIPTION
## Problems with the current clustering

Pax's current clustering is not very good:
- As Alex has noted (see #181 and #158), close S1s rarely get split. In pftest results (see bottom of this PR) you can see this in the S1sClose test performance --  although Xerawdp doesn't seem to be very good either: it can resolve a few S1s separated by <200 ns, but the test indicates such signals would be missed most of the time.
- S2s often have some photons cut off from their tails: these are then usually reported as 'unknown' peaks, but they could become anything (including S1). You can see this in the SmallS2s test, and any other test that uses S2s.

Both issues stem from a single problem: the GapSize clustering algorithm splits hits if they are separated by a large enough gap, _no matter where they are in relation to other hits_. Large gaps are likely in tails of signals, while between two signals, especially large signals, the gaps can be small or even non-existent. Making the gap threshold depend on the area of hits in the cluster so far (see #129) may help the clustering a little, but does not get to the heart of this problem.
## How this algorithm works

This plugin is inspired by the 'natural breaks' algorithm, which is a clustering algorithm specifically for 1d. The clustering proceeds in two steps:
1. Hits are clustered by breaking whenever a gap larger than `max_gap_size_in_cluster` is encountered. (this is just the old GapSize algorithm)
2. Next, These clusters are declustered. Any gaps larger than `min_gap_size_for_break` are tested by computing a 'goodness of split' for splitting the cluster at that point. Gaps are tried from largest gap to smallest. If the goodness of split is larger than a threshold (which is configurable function of the total number of hits in the cluster) the cluster is split at that gap and the declustering is called recursively for the newly minted clusters.
## The goodness of split function

```
0.5 * sad(all_hits) / (sad(left cluster) + sad(right cluster) + gap between clusters) - 1
```
- sad is the sum of absolute deviation (weighted by hit area) from the mean, calculated on all _endpoints_ of hits in the cluster. 
- The reason we use endpoints, rather than hit centers, is compatibility with high-energy signals. These can have a single long hit in all channels, which won't have any short hits near to its center.
- The gap between clusters in the denominator is a penalty term that discourages splitting of very small signals.
- The reason we use sum absolute deviation instead of something like the root of the sum square deviation is that it is less sensitive to outliers. Clustering should not trim tails of peaks.
- The goodness of split usually takes a value around [-0.5, +0.5], but it can go much higher or lower if the split is particularly good or bad.  
## How to choose the thresholds

I chose the threshold function min_split_goodness(n_hits) so S2s shouldn't be split up: I got some S2s from the waveform simulator, computed the largest split goodness in each, took the 99th percentile of those, then put the threshold well above that. I did the same for the max_gap_size_in_cluster threshold. I'll write a note about this and upload the notebooks I used.

A disadvantage of this approach, or any algorithm that exploits detailed knowledge of signal shapes, is that the threshold-choosing has to be re-done if the S2 shape changes, e.g. because of a change in liquid level, drift field, and especially the anode field.

For special analyses like the Krypton S1s, you can try to lower the threshold function (e.g. try max(0.1, 0.9 - 0.8/150 \* n)

The reasons I prefer on err towards splitting too little rather than too much are
- Single electrons are very common, and once split they can cause fake S1s. We know there are some wide, bi-modal single electrons not modeled by the waveform simulator, originating from electrons coming at the anode sideways. 
- Unresolved clusters can still be tagged as such in the classification. Improperly split peaks can't easily be joined again.
## Evaluation with Pftest (simulated waveforms)

I uploaded the resuls here:
https://xecluster.lngs.infn.it/dokuwiki/lib/exe/fetch.php?media=xenon:xenon1t:processor:pftest_summary_results_20150710.zip
- S1sClose shows about a factor 2 improvement in splitting S1s. Since pax's classification still isn't optimized, I'm not surprised some of these S1 pairs still get tagged as S2s. Keep in mind these are just 5pe S1s, the separation power for larger S1s is likely better (but we should really test this separately)
- S2sClose, SmallS2s, TenElectronS2s, and SmallShallowS2s show the 'tail cutting' problem has been resolved. 
- From S2sClose we see we can see the S2 splitting efficiency hasn't improved much, but it wasn't that bad. (the 'merged' S2s 5 mm apart are a bug related to the test configuration error)
- SmallS1s and TwoPeS1s show no change: S1s aren't improperly split.
- SingleElectronS2s shows single electrons are essentially never improperly split anymore.
- OnePes close shows 1pes get merged up to >500ns separation, rather than 450 ns. This is just because the gap size threshold has been raised from 450 to 600 in the first stage. I don't think this matters much, this is mainly a test for the classification (make sure 2 dark rates don't get tagged as an S1).

I ran these tests before I committed the weighing by area -- this shouldn't matter at the low energies tested by the waveform simulator, but of course it takes just a few hours of the Nikhef cluster's time to run them again.
