### PR TITLE
Temporarily raise hitfinder low threshold after very large hits

### DIFF
--- a/pax/config/XENON100.ini
+++ b/pax/config/XENON100.ini
@@ -41,55 +41,31 @@ transform = [
 
 
 [HitFinder.FindHits]
+# For detailed description of what these settings do, see the documentation / plugin docstring.
+
 # Compute baseline on first n samples in pulse:
 initial_baseline_samples = 40
 
 # Max hits to look for in each pulse: rest will be ignored
-# After large peaks the zero-length encoding can fail, making a huge pulse with many hits
-# If set too low, you risk missing some hits in such events.
-# If set too high, it will degrade performance (though the effect appears to be small)
-# Don't set to infinity though: we need to allocate memory for this...
 max_hits_per_pulse = 1000
 
 # Diagnostic plots settings
 make_diagnostic_plots = 'never'     # Can be always, never, tricky cases, no hits, hits only
 make_diagnostic_plots_in = 'hitfinder_diagnostic_plots'
 
-##
-# The pax hitfinder can work with three types of thresholds.
-# If several are enabled (are set > 0), the highest threshold is used in each event.
-#   - A hit has to pass the high_threshold somewhere
-#   - A hit starts/ ends when it passes the low_threshold.
-# In what follows high/positive means 'signal like' (i.e. the PMT voltage becomes more negative)
-##
-
 # Threshold 1: Height / noise.
-# This threshold operates on the height above baseline / noise level
-# The noise level is deteremined in each pulse as
-#   (<(w - baseline)**2>)**0.5
-# with the average running *only* over samples < baseline!
 height_over_noise_high_threshold = 8       # Reasonable and conservative for run10: see xenon:xenon100:analysis:led_pax
 height_over_noise_low_threshold = 1
 
 # Threshold 2: Absolute ADC counts above baseline
-# If there is measurable noise in the waveform, you don't want the thresholds to fall to 0 and crash pax.
-# This happens for pulses constant on initial_baseline_samples.
-# Please use this as a deep fallback only, unless you know what mess you're getting yourself into!
 absolute_adc_counts_high_threshold = 1   # ADC counts
 absolute_adc_counts_low_threshold = 1   # ADC counts
 
 # Threshold 3:  - Height / minimum
-# This threshold operates on the (-) height above baseline / height below baseline of the lowest sample in pulse
-# Using this threshold protects you against sudden up & down fluctuations, especially in large pulses
-# However, keep in mind that one large downfluctuation will cause a sensitivity loss throughout an entire pulse;
-# if you have ZLE off, this may be a bad idea...
 height_over_min_high_threshold = 2
 height_over_min_low_threshold = 0
 
-# Bonus threshold
-# The low threshold can be raised to a fraction of the hit height once a really high hit is encountered
-# The low threshold will never be lowered by this and the effect is only for a single pulse.
-# This helps prevent any probably unphysical (and in any case immaterial) tails of very high hits to mess up clustering
+# Raise low threshold temporarily to fraction of hit height for rest of pulse
 dynamic_low_threshold_coeff = 0.01
 
 

--- a/pax/plugins/signal_processing/HitFinder.py
+++ b/pax/plugins/signal_processing/HitFinder.py
@@ -1,8 +1,6 @@
 """Hit finding plugin
 
-If you get an error from either of the numba methods in this plugin (exception from native function blahblah)
-Try commenting the @jit decorators, which will run a slow, pure-python version of the methods, allowing you to debug.
-Don't forget to re-enable the @jit -- otherwise it will run quite slow!
+
 """
 
 
@@ -17,6 +15,59 @@ from pax import plugin, datastructure, utils
 
 
 class FindHits(plugin.TransformPlugin):
+    """Finds hits in pulses
+    First, the baseline is computed as the mean of the first initial_baseline_samples in the pulse.
+    Next, hits are found based on a high and low threshold:
+     - A hit starts/ends when it passes the low_threshold
+     - A hit has to pass the high_threshold somewhere.
+
+    Thresholds can be set on three different quantities. These are computed per pulse, the highest is used.
+    Here high/positive means 'signal like' (i.e. the PMT voltage becomes more negative)
+
+    1) Height over noise threshold
+           Options: height_over_noise_high_threshold, height_over_noise_low_threshold
+       This threshold operates on the height above baseline / noise level
+       The noise level is deteremined in each pulse as
+         (<(w - baseline)**2>)**0.5
+       with the average running *only* over samples < baseline!
+
+    2) Absolute ADC counts above baseline
+           Options: absolute_adc_counts_high_threshold, absolute_adc_counts_low_threshold
+       If there is measurable noise in the waveform, you don't want the thresholds to fall to 0 and crash pax.
+       This happens for pulses constant on initial_baseline_samples.
+       Please use this as a deep fallback only, unless you know what mess you're getting yourself into!
+
+    3) - Height / minimum
+           Options: height_over_min_high_threshold, height_over_min_LOW_threshold
+       Using this threshold protects you against sudden up & down fluctuations, especially in large pulses
+       However, keep in mind that one large downfluctuation will cause a sensitivity loss throughout an entire pulse;
+       if you have ZLE off, this may be a bad idea...
+       This threshold operates on the (-) height above baseline / height below baseline of the lowest sample in pulse
+
+
+    Edge cases:
+
+    1) After large peaks the zero-length encoding can fail, making a huge pulse with many hits.
+       If more than max_hits_per_pulse hits are found in a pulse, the rest will be ignored.
+       If this threshold is set too low, you risk missing some hits in such events.
+       If set too high, it will degrade performance. Don't set to infinity, we need to allocate memory for this...
+
+    2) Very high hits (near ADC saturation) sometimes have a long tail. To protect against this, we raise the
+       low threshold to a fraction dynamic_low_threshold_coeff of the hit height after a hit has been encountered.
+       This is a temporary change for just the remainder of a pulse.
+       Also, if the hit height * dynamic_low_threshold_coeff is lower than the low threshold, nothing is changed.
+
+    Diagnostic plot options:
+        make_diagnostic_plots can be always, never, tricky cases, no hits, hits only. This controls whether to make
+        diagnostic plots showing individual pulses and the hitfinder's interpretation of them. For details on what
+        constitutes a tricky case, check the source.
+        make_diagnostic_plots_in sets the directory where the diagnostic plots are created.
+
+    Debugging tip:
+    If you get an error from one of the numba methods in this plugin (exception from native function blahblah)
+    Try commenting the @jit decorators, which will run a slow, pure-python version of the methods,
+    allowing you to debug. Don't forget to re-enable the @jit -- otherwise it will run quite slow!
+    """
 
     def startup(self):
         c = self.config


### PR DESCRIPTION
This is a small change to the hitfinder to deal with really, really large hits. I'm talking about brutes like this:

![event0000_pulse26656-28191_ch084](https://cloud.githubusercontent.com/assets/4354311/8629037/efbc8086-2757-11e5-91e9-3730275b8c6a.png)

As you can see, it takes a while for the PMT/Amplifier to go back to zero after such a large (even saturating) signal. This shows up in the sum waveform like this:

![before](https://cloud.githubusercontent.com/assets/4354311/8629055/1d648de4-2758-11e5-8828-745b67abc353.png)

Because the hit is so long, it also messes up the clustering. In this event we don't particularly care, but there are instances where we would (single electron / S2b after large S1, see e.g. event 37).

This change raises the hitfinder 'low threshold' (the threshold that decides when hits start or end) to 1% of the hit height once a hit has been found, if that does indeed raise the threshold, for just that pulse. Usually the low threshold ends up at 0.05 pe/bin or so, which means medium-size signals will already raise it a bit. This won't hurt you much: if you've got a signal pumping out 30 or more pe/sample in a single channel, you don't care much if you might miss a few straggling single photons behind it in the same pulse in that channel. When a new pulses start, you start with a clean slate. 

The effect is this:

![event0000_pulse26656-28191_ch084 2](https://cloud.githubusercontent.com/assets/4354311/8629200/7166c050-2759-11e5-930f-a41184dda1db.png)

![after](https://cloud.githubusercontent.com/assets/4354311/8629203/740d2e0c-2759-11e5-9c36-f02980cedfec.jpg)
