### PR TITLE
Optimized natural breaks

### DIFF
--- a/pax/plugins/signal_processing/Cluster.py
+++ b/pax/plugins/signal_processing/Cluster.py
@@ -465,31 +465,7 @@ class NaturalBreaks(ClusterPlugin):
                                 self.right[hit_indices[split_index:]],
                                 weights=self.area[hit_indices[split_index:]],)
         denominator += self.left[hit_indices[split_index]] - self.right[hit_indices[split_index - 1]]
-        result = -1 + 0.5 * numerator / denominator
-
-        x = np.concatenate((self.left[hit_indices], self.right[hit_indices]))
-        a = np.concatenate((self.area[hit_indices], self.area[hit_indices]))
-        xleft = np.concatenate((self.left[hit_indices][:split_index],
-                                self.right[hit_indices][:split_index]))
-        aleft = np.concatenate((self.area[hit_indices][:split_index],
-                                self.area[hit_indices][:split_index]))
-        xright = np.concatenate((self.left[hit_indices][split_index:],
-                                 self.right[hit_indices][split_index:]))
-        aright = np.concatenate((self.area[hit_indices][split_index:],
-                                 self.area[hit_indices][split_index:]))
-
-        if (sub_abs_dev(x, weights=a) - numerator) / numerator > 0.001:
-            raise ValueError("Nominator is already wrong: %s != %s" % (sub_abs_dev(x, weights=a), numerator))
-
-        result2 = 0.5 * sub_abs_dev(x, weights=a) / (
-            sub_abs_dev(xleft, weights=aleft) + sub_abs_dev(xright, weights=aright) +
-            self.left[hit_indices[split_index]] -
-            self.right[hit_indices[split_index - 1]]) - 1
-
-        if (result - result2) / result > 0.001:
-            raise ValueError("%s != %s" % (result, result2))
-
-        return result
+        return -1 + 0.5 * numerator / denominator
 
 
 @numba.jit(nopython=True)
@@ -523,16 +499,3 @@ def indices_of_largest_n(a, n):
     if len(a) == 0:
         return []
     return np.argsort(-a)[:min(n, len(a))]
-
-
-
-def sub_abs_dev(x, weights=None):
-    sum_w = np.sum(weights)
-    if weights is None:
-        return np.sum(np.abs(x - np.mean(x)))
-    elif sum_w == 0:
-        raise ValueError("Weights sum to zero: can't be normalized")
-    else:
-        # To normalize to the case with all weights 1, we multipy by len(x) / sum_w
-        #
-        return np.sum(weights * np.abs(x - np.average(x, weights=weights))) * len(x) / sum_w


### PR DESCRIPTION
This uses numba to improve the speed of the natural breaks declustering by a factor 2. It also fixes a bug in the previous implementation: the deviations from the mean hit time were computed with respect to the ordinary mean hit time rather than the weighted hit time.

If you want to check the code still does the same as the previous code (except for the bugfix), go back one commit and run pax, it will check every clustering computation.

This optimization isn't really necessary, as the declustering takes only about ~20% of the total pax runtime currently. So if you feel the optimization does not justify added complexity, just shoot this down, I'm not particularly attached to it. I'll just fix only the bug in master in that case.
