### PR TITLE
Keep scikit-learn  in the installation prerequisites for pax. Otherwi…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ some contain C++ code which must be compiled. If you have Anaconda you can get a
 for your platform using the `conda` tool::
 
   conda update conda
-  conda create -n pax numpy scipy matplotlib pandas cython h5py numba pip snappy python-snappy pytables
+  conda create -n pax numpy scipy matplotlib pandas cython h5py numba pip python-snappy pytables scikit-learn
   
 Whenever you want to use `pax`, you have to run the following command to set it up::
   


### PR DESCRIPTION
Keep scikit-learn  in the installation prerequisites for pax. Otherwise it gets picked up from pypi, not from conda/binstar.

Also, remove snappy from the list, as python-snappy already has it as a dependency, so it will be picked up automatically by conda.
