### PR TITLE
made pos rec work with high indices PMTs

### DIFF
--- a/pax/plugin.py
+++ b/pax/plugin.py
@@ -148,7 +148,7 @@ class PosRecPlugin(TransformPlugin):
         self.pmt_locations = np.zeros((len(self.pmts), 2))
         for ch in self.pmts:
             for dim in ('x', 'y'):
-                self.pmt_locations[ch][{'x': 0, 'y': 1}[dim]] = self.config['pmt_locations'][ch][dim]
+                self.pmt_locations[ch-self.pmts[0]][{'x': 0, 'y': 1}[dim]] = self.config['pmt_locations'][ch][dim]
 
         TransformPlugin._pre_startup(self)
 

--- a/pax/plugins/posrec/MaxPMT.py
+++ b/pax/plugins/posrec/MaxPMT.py
@@ -7,4 +7,4 @@ class PosRecMaxPMT(plugin.PosRecPlugin):
     """
     def reconstruct_position(self, peak):
         max_pmt = np.argmax(peak.area_per_channel[self.pmts])
-        return self.pmt_locations[self.pmts[max_pmt]]
+        return self.pmt_locations[max_pmt]


### PR DESCRIPTION
made pos rec work with high indices PMTs.
Position reconstruction algorithms expected the top PMTs to have low indices (0...N/2). Now that's not necessary anymore.
