### PR TITLE
Protect hitfinder against ZLE breakdown

### DIFF
--- a/pax/config/XENON100.ini
+++ b/pax/config/XENON100.ini
@@ -82,13 +82,16 @@ height_over_noise_low_threshold = 1
 absolute_adc_counts_high_threshold = 1   # ADC counts
 absolute_adc_counts_low_threshold = 1   # ADC counts
 
-
 # Threshold 3:  - Height / minimum
 height_over_min_high_threshold = 2
 height_over_min_low_threshold = 0
 
 # Raise low threshold temporarily to fraction of hit height for rest of pulse
 dynamic_low_threshold_coeff = 0.01
+
+# Protection against ZLE breakdown
+# Ignore pulses which reach to the end and are longer than ...
+terminal_pulse_length_threshold = 10 * us
 
 [BuildPeaks.GapSizeClustering]
 # Start a new cluster / peak if a gap larger than this is encountered

--- a/pax/config/XENON100_LED.ini
+++ b/pax/config/XENON100_LED.ini
@@ -15,8 +15,9 @@ input = 'XED.ReadXED'
 output = 'Table.TableWriter'
 
 
-#[HitFinder.FindHits]
-#make_diagnostic_plots = 'hits only'
+[HitFinder.FindHits]
+# Zero-length encoding is off in LED mode, so we should turn of ZLE breakdown protection too
+terminal_pulse_length_threshold = float('inf')
 
 
 [Table.TableWriter]


### PR DESCRIPTION
This lets the hitfinder ignore long pulses which extend to the very end of the event. These are a result of zero-length encoding breakdown, which in turn almost always results from a channel becoming very noisy after a large S2. 

An info message will be printed the first three times this happens, then it becomes a debug message. The threshold for 'long' is configurable (currently 10 us) and of course it is turned off during LED mode (when ZLE is not activated).

Before:
![000028](https://cloud.githubusercontent.com/assets/4354311/10868262/6944b9e4-8088-11e5-9ac6-34497665f371.png)

After:
![000028](https://cloud.githubusercontent.com/assets/4354311/10868253/43a4b91e-8088-11e5-9eb2-a1bb4d6e4dde.png)

(note this is before the clustering improvement in #254)
