### PR TITLE
made BasicProperties work with high index top PMTs

### DIFF
--- a/pax/plugins/peak_processing/BasicProperties.py
+++ b/pax/plugins/peak_processing/BasicProperties.py
@@ -12,6 +12,7 @@ class BasicProperties(plugin.TransformPlugin):
     """
 
     def transform_event(self, event):
+        first_top_ch = np.min(np.array(self.config['channels_top']))
         last_top_ch = np.max(np.array(self.config['channels_top']))
 
         for peak in event.peaks:
@@ -41,13 +42,13 @@ class BasicProperties(plugin.TransformPlugin):
             peak.mean_amplitude_to_noise /= peak.area
 
             # Compute top fraction
-            peak.area_fraction_top = np.sum(peak.area_per_channel[:last_top_ch + 1]) / peak.area
-            peak.hits_fraction_top = np.sum(peak.hits_per_channel[:last_top_ch + 1]) / peak.area
+            peak.area_fraction_top = np.sum(peak.area_per_channel[first_top_ch:last_top_ch + 1]) / peak.area
+            peak.hits_fraction_top = np.sum(peak.hits_per_channel[first_top_ch:last_top_ch + 1]) / peak.area
 
             # Compute timing quantities
             peak.hit_time_mean, peak.hit_time_std = weighted_mean_variance(hits['center'], hits['area'])
             peak.hit_time_std **= 0.5  # Convert variance to std
-            peak.n_contributing_channels_top = np.sum((peak.area_per_channel[:last_top_ch + 1] > 0))
+            peak.n_contributing_channels_top = np.sum((peak.area_per_channel[first_top_ch:last_top_ch + 1] > 0))
 
             if peak.n_contributing_channels == 0:
                 raise RuntimeError("Every peak should have at least one contributing channel... what's going on?")


### PR DESCRIPTION
Before, all channels from 0 to the last top PMT number were considered to be top. 
(e.g: channels 0...N/2 =  bottom, N/2+1....N = top . )
That caused some fields to be wrong
