### PR TITLE
Rootfixmemory

### DIFF
--- a/pax/plugins/io/ROOTClass.py
+++ b/pax/plugins/io/ROOTClass.py
@@ -1,7 +1,6 @@
 import os
 import re
 
-from six.moves import input
 import numpy as np
 import ROOT
 
@@ -148,7 +147,6 @@ class WriteROOTClass(plugin.OutputPlugin):
         self.set_root_object_attrs(event, self.root_event)
         self.event_tree.Fill()
 
-
     def set_root_object_attrs(self, python_object, root_object):
         """Set attribute values of the root object based on data_model
         instance python object
@@ -172,7 +170,6 @@ class WriteROOTClass(plugin.OutputPlugin):
                 root_vector.clear()
                 for element_python_object in list_of_elements:
                     element_root_object = getattr(ROOT, element_name)()
-                    #ROOT.SetOwnership(element_root_object, True)
                     self.set_root_object_attrs(element_python_object, element_root_object)
                     root_vector.push_back(element_root_object)
                 self.last_collection[element_name] = list_of_elements


### PR DESCRIPTION
Should fix the memory leak (at least for the biggest part involving numpy arrays to ROOT PyXXBuffers). 
This also required patching ROOT (5 and 6). See the discussion on that [here](https://root.cern.ch/phpBB3/viewtopic.php?f=14&t=20770&p=89902). 
Patches to ROOT for python3 are done already ([Utility.cxx](https://github.com/remenska/root-conda-recipes/blob/master/root6/python34.patch) and [TPyBufferFactory.cxx](https://github.com/remenska/root-conda-recipes/blob/master/root6/python34_1.patch))
