### PR TITLE
Fix for progress bar

### DIFF
--- a/examples/muenster/EVE_file.py
+++ b/examples/muenster/EVE_file.py
@@ -148,9 +148,9 @@ class EveInput(InputFromFolder):
         self.stop_time = int(
             self.start_time + self.file_caen_pars["nof_samples"] * self.sample_duration)
 
-    def get_first_and_last_event_number(self, filename):
-        """Return the first and last event number in file specified by filename"""
-        print("getting first and last event number")
+    def get_event_number_info(self, filename):
+        """Return the first, last and total event numbers in file specified by filename"""
+        print("getting first, last and total event number")
         with open(filename, 'rb') as evefile:
             evefile.seek(0, 2)
             filesize = evefile.tell()
@@ -172,7 +172,7 @@ class EveInput(InputFromFolder):
 
             self.event_positions = positions
 
-            return 0, j - 3
+            return 0, j - 3, j - 3 + 1
 
     def close(self):
         """Close the currently open file"""

--- a/pax/FolderIO.py
+++ b/pax/FolderIO.py
@@ -52,18 +52,18 @@ class InputFromFolder(plugin.InputPlugin):
         self.select_file(0)
 
         # Set the number of total events
-        self.number_of_events = sum([fr['last_event'] - fr['first_event'] + 1
-                                     for fr in self.raw_data_files])
+        self.number_of_events = sum([fr['n_events'] for fr in self.raw_data_files])
 
     def init_file(self, filename):
         """Find out the first and last event contained in filename
-        Appends {'filename': ..., 'first_event': ..., 'last_event':...} to self.raw_data_files
+        Appends {'filename': ..., 'first_event': ..., 'last_event':..., 'n_events':...} to self.raw_data_files
         """
-        first_event, last_event = self.get_first_and_last_event_number(filename)
+        first_event, last_event, n_events = self.get_event_number_info(filename)
         self.log.debug("InputFromFolder: Initializing %s", filename)
         self.raw_data_files.append({'filename': filename,
                                     'first_event': first_event,
-                                    'last_event': last_event})
+                                    'last_event': last_event,
+                                    'n_events': n_events})
 
     def select_file(self, i):
         """Selects the ith file from self.raw_data_files for reading
@@ -129,11 +129,20 @@ class InputFromFolder(plugin.InputPlugin):
         return self.get_single_event_in_current_file(event_number)
 
     # If reading in from a folder-of-files format not written by FolderIO,
-    # you'll probably have to overwrite this. (e.g. XED does)
-    def get_first_and_last_event_number(self, filename):
-        """Return the first and last event number in file specified by filename"""
-        _, _, first_event, last_event = os.path.splitext(os.path.basename(filename))[0].split('-')
-        return int(first_event), int(last_event)
+    # you'll probably have to overwrite this. (e.g. ReadXED does)
+    def get_event_number_info(self, filename):
+        """Return the first, last and total event numbers in file specified by filename"""
+        stuff = os.path.splitext(os.path.basename(filename))[0].split('-')
+        if len(stuff) == 4:
+            # Old format, which didn't have an event numbers field... progress bar will be off...
+            _, _, first_event, last_event = stuff
+            return int(first_event), int(last_event), int(last_event) - int(first_event) + 1
+        elif len(stuff) == 5:
+            _, _, first_event, last_event, n_events = stuff
+            return int(first_event), int(last_event), int(n_events)
+        else:
+            raise ValueError("Invalid file name: %s. "
+                             "Should be tpcname-something-firstevent-lastevent-nevents.%s" % self.file_extension)
 
     ##
     # Child class should override these
@@ -241,11 +250,12 @@ class WriteToFolder(plugin.OutputPlugin):
         # Rename the temporary file to reflect the events we've written to it
         os.rename(self.tempfile,
                   os.path.join(self.output_dir,
-                               '%s-%d-%06d-%06d.%s' % (self.config['tpc_name'],
-                                                       self.config['run_number'],
-                                                       self.first_event_in_current_file,
-                                                       self.last_event_written,
-                                                       self.file_extension)))
+                               '%s-%d-%06d-%06d-%06d.%s' % (self.config['tpc_name'],
+                                                            self.config['run_number'],
+                                                            self.first_event_in_current_file,
+                                                            self.last_event_written,
+                                                            self.events_written_to_current_file,
+                                                            self.file_extension)))
 
     def shutdown(self):
         if self.has_shut_down:

--- a/pax/core.py
+++ b/pax/core.py
@@ -126,12 +126,8 @@ class Processor:
                                  len(plugin_names['input']))
 
             self.input_plugin = self.instantiate_plugin(plugin_names['input'][0])
-
-            self.stop_after = float('inf')
-            if 'stop_after' in pc and pc['stop_after'] is not None:
-                self.stop_after = pc['stop_after']
-
-            self.total_number_events = min(self.input_plugin.number_of_events, self.stop_after)
+            self.number_of_events = self.input_plugin.number_of_events
+            self.stop_after = pc.get('stop_after', float('inf'))
 
             # Parse the event numbers file, if one is given
             if pc.get('event_numbers_file', None) is not None:
@@ -140,7 +136,7 @@ class Processor:
 
             if pc.get('events_to_process', None) is not None:
                 # The user specified which events to process:
-                self.total_number_events = min(len(pc['events_to_process']), self.stop_after)
+                self.number_of_events = len(pc['events_to_process'])
 
                 def get_events():
                     for event_number in pc['events_to_process']:
@@ -149,6 +145,8 @@ class Processor:
             else:
                 # Let the input plugin decide which events to process:
                 self.get_events = self.input_plugin.get_events
+
+            self.number_of_events = min(self.number_of_events, self.stop_after)
 
         else:
             # During tests there is often no input plugin
@@ -433,7 +431,7 @@ class Processor:
         self.timer.punch()
         for i, event in enumerate(tqdm(self.get_events(),
                                        desc='Event',
-                                       total=self.total_number_events)):
+                                       total=self.number_of_events)):
             self.input_plugin.total_time_taken += self.timer.punch()
 
             if i >= self.stop_after:

--- a/pax/plugins/io/XED.py
+++ b/pax/plugins/io/XED.py
@@ -61,12 +61,13 @@ class ReadXED(InputFromFolder):
 
     file_extension = 'xed'
 
-    def get_first_and_last_event_number(self, filename):
-        """Return the first and last event number in file specified by filename"""
+    def get_event_number_info(self, filename):
+        """Return the first, last and total event numbers in file specified by filename"""
         with open(filename, 'rb') as xedfile:
             fmd = np.fromfile(xedfile, dtype=xed_file_header, count=1)[0]
             return (fmd['first_event_number'],
-                    fmd['first_event_number'] + fmd['events_in_file'] - 1)
+                    fmd['first_event_number'] + fmd['events_in_file'] - 1,
+                    fmd['events_in_file'])
 
     def close(self):
         """Close the currently open file"""


### PR DESCRIPTION
This ensures pax's progress bar doesn't freak out when processing files with non-continuous event numbers: see #285. Unfortunately this only applies to newly written FolderIO data files, as the total number of events information had to be added to the file names to ensure it works for all FolderIO plugins (and to avoid always having to read all the files in a directory).

Of course it is a bad karma to store metadata in filenames, but we should've realized that earlier: the FolderIO filenames already carry the first and last event numbers (which are used to see if an event is in a file). If it's any consolation, the important metadata (pax version and config dump) is stored properly in the pax_info.json file written along with any FolderIO dataset (but not the root files, see #286).

A small API change in FolderIO was also needed. @xolotl90 may want to have a look if I changed things correctly for the EVE plugin.
