### PR TITLE
Fix ZLE emulation threshold

### DIFF
--- a/pax/config/Simulation.ini
+++ b/pax/config/Simulation.ini
@@ -9,3 +9,4 @@ max_intervals =                       32                  # See CAEN 1724 manual
 zle_threshold =                       30 # ADC counts     # See any XENON100 DAX XML file. Ini file has something else, but is overridden.
 samples_to_store_before =             50                  # Observation?? Some config??
 samples_to_store_after  =             50                  # Observation?? Some config??
+special_thresholds =                  {'1': 100, '2': 100}   # Erik's observation, see #273

--- a/pax/config/XENON100.ini
+++ b/pax/config/XENON100.ini
@@ -295,10 +295,6 @@ s1_patterns_zoom_factor =             1                   # Use a very zoomed-ou
 s2_mean_area_fraction_top =           0.555               # S2 asymmetry average = 0.11, top fraction = (1 + A)/2. Todo: check / add ref!
 
 
-# Compensate for channel 1 and 2 problem visible in LED calibration, but not in real data
-adjust_noise_amplitude    = {'1': 0.5, '2': 0.5}          # Multiply noise amplitude in specific channels with this amount
-
-
 
 # Global settings, passed to every plugin
 [DEFAULT]

--- a/pax/plugins/ZLE.py
+++ b/pax/plugins/ZLE.py
@@ -44,10 +44,18 @@ class SoftwareZLE(plugin.TransformPlugin):
             if self.debug:
                 plt.plot(w)
 
+            # Get the ZLE threshold
+            # Note a threshold of X digitizer bins actually means that the data acquisition
+            # triggers when the waveform becomes greater than X, i.e. X+1 or more (see #273)
+            # hence the + 1
+            if str(pulse.channel) in self.config.get('special_thresholds', {}):
+                threshold = self.config['special_thresholds'][str(pulse.channel)] + 1
+            else:
+                threshold = self.config['zle_threshold'] + 1
+
             # Find intervals above ZLE threshold
-            high_threshold = low_threshold = self.config['zle_threshold']
             n_itvs_found = find_intervals_above_threshold(w.astype(np.float64),
-                                                          high_threshold, low_threshold, zle_intervals_buffer,
+                                                          threshold, threshold, zle_intervals_buffer,
                                                           dynamic_low_threshold_coeff=0)
 
             if n_itvs_found == self.config['max_intervals']:


### PR DESCRIPTION
This fixes the issues with the XENON100 ZLE emulation raised in #273:
- The ZLE threshold can be set differently for each channel
- It is set to 100 for channels 1 and 2
- Off-by-one error in threshold interpretation fixed

Thanks again to @ErikHogenbirk for spotting this, could you briefly glance over the fix and merge if ok?
