### PR TITLE
Fix ROOT output long64 bug

### DIFF
--- a/pax/config/_base.ini
+++ b/pax/config/_base.ini
@@ -158,6 +158,23 @@ extra_fields = {'Event': [('s1s', 'std::vector <Int_t>',  "field.clear()\n[field
 # (not the tqdm progress bar)
 exclude_compilation_from_timer = True
 
+# Mapping of python/numpy types to C++/ROOT types
+type_mapping = {'float':   'Float_t',
+                'float64': 'Double_t',
+                'float32': 'Float_t',
+                'int':     'Int_t',
+                'int16':   'Short_t',
+                'int32':   'Int_t',
+                'int64':   'Long64_t',
+                'bool':    'Bool_t',
+                'bool_':   'Bool_t',
+                'long':    'Long64_t',
+                'str':     'TString'}
+
+# Force the types of certain fields to be different from the default type mappings
+force_types = {'start_time': 'Long64_t',
+               'stop_time': 'Long64_t'}
+
 
 [Table.TableWriter]
 output_format = 'hdf5'      # hdf5, csv, numpy, html, json, root


### PR DESCRIPTION
This fixes the problem with event.start_time and event.stop_time in the root output spotted by @yz2614 in #281. start_time and stop_time are 64-bit integers, which are represented by the same object (int) as all other integers in python 3, but should be represented by a different type (Long64_t, not Int_t) in C++/ROOT. 

I've now forced WriteROOTClass to declare these branches as Long64_t in the class. This is a somewhat dirty solution, if we need to store any other long integers we'll have to update the force_type dict in the configuration.

You can test this as follows: clear your rootpy cache

```
rm -rf ~/.cache/rootpy
```

then write a small ROOT file:

```
paxer --stop_after 50 --output test
```

then convert it to csv:

```
paxer --config reprocess --input test --input_type root --output_type csv --output test_csv
```

Then inspecting test_csv/Event.csv. 

Before fix:

```
,Event,dataset_name,event_number,interactions_start,n_channels,n_interactions,n_peaks,peaks_start,sample_duration,start_time,stop_time
0,0,b'xe100_120402_2000_000000.xed',0,0,243,5,45,0,10,606771456,607171456
1,1,b'xe100_120402_2000_000000.xed',1,0,243,1,17,0,10,638229504,638629504
...
34,34,b'xe100_120402_2000_000000.xed',34,0,243,10,16,0,10,2052656640,2053056640
35,35,b'xe100_120402_2000_000000.xed',35,0,243,0,79,0,10,2075513600,2075913600
36,36,b'xe100_120402_2000_000000.xed',36,0,243,5,14,0,10,-2131564800,-2131164800
37,37,b'xe100_120402_2000_000000.xed',37,0,243,0,9,0,10,-2085504768,-2085104768
...
```

After fix:

```
,Event,dataset_name,event_number,interactions_start,n_channels,n_interactions,n_peaks,peaks_start,sample_duration,start_time,stop_time
0,0,b'xe100_120402_2000_000000.xed',0,0,243,5,45,0,10,1333389610015430912,1333389610015830912
1,1,b'xe100_120402_2000_000000.xed',1,0,243,1,17,0,10,1333389610046888960,1333389610047288960
...
34,34,b'xe100_120402_2000_000000.xed',34,0,243,10,16,0,10,1333389611461316096,1333389611461716096
35,35,b'xe100_120402_2000_000000.xed',35,0,243,0,79,0,10,1333389611484173056,1333389611484573056
36,36,b'xe100_120402_2000_000000.xed',36,0,243,5,14,0,10,1333389611572061952,1333389611572461952
37,37,b'xe100_120402_2000_000000.xed',37,0,243,0,9,0,10,1333389611618121984,1333389611618521984
...
```

You can also confirm with tree->Print() the type of start_time and stop_time is now Long64_t whereas it used to be Int_t.

I tried looking at the ROOT file with my local TBrowser, however I (still) can't see the histogram if I draw events.start_time. This could be because I'm on windows, or because I haven't loaded in the event class.
