### PR TITLE
Safeguard against multiprocessing hangs

### DIFF
--- a/bin/paxer
+++ b/bin/paxer
@@ -89,7 +89,7 @@ class BaseProcess(multiprocessing.Process):
     """
 
     def __init__(self, task_queue, result_queue,
-                 input_done, process_done, output_done,
+                 input_done, process_done, output_done, has_crashed,
                  config_names, config_path, config_dict):
         multiprocessing.Process.__init__(self)
 
@@ -102,6 +102,7 @@ class BaseProcess(multiprocessing.Process):
         self.input_done = input_done
         self.process_done = process_done
         self.output_done = output_done
+        self.has_crashed = has_crashed
 
         # pax configuations
         self.config_names = config_names
@@ -114,12 +115,11 @@ class BaseProcess(multiprocessing.Process):
 
 
 class ProcessorEvents(BaseProcess):
-
     """Thread for processing single events
 
     This thread will be fed via the task queue and report its results via the
     result queue.  It will initialize its own 'pax' Processor instance.  It
-    waits until it has received a 'poisson pill', which tells it to shut down.
+    waits until it has received a 'poison pill', which tells it to shut down.
     """
 
     def run(self):
@@ -128,28 +128,34 @@ class ProcessorEvents(BaseProcess):
                            config_paths=self.config_path,
                            config_dict=self.config_dict)
 
-        # Loop until a 'poisson pill' found (next_events == None)
+        # Loop until a 'poison pill' found (next_events == None)
         while True:
             next_events = self.task_queue.get()
             answer = []
-            if next_events is None:  # Poison pill of None means shutdown
-                p.log.info('Exiting')
+            if next_events is None or self.has_crashed.is_set():  # Poison pill of None means shutdown
+                p.log.info('Exiting processor worker')
                 p.shutdown()
                 self.task_queue.task_done()
                 break
 
             # If not None, means these are events to process
-            for event in next_events:
-                answer.append(p.process_event(event))
+            try:
+                for event in next_events:
+                    answer.append(p.process_event(event))
+            except Exception as e:
+                # Oh no, a crash!
+                self.has_crashed.set()
+                self.task_queue.task_done()
+                # Turn into a "vampire" which slurps the entire task queue
+                for _ in self.task_queue.get():
+                    self.task_queue.task_done()
+                raise e
 
             # Notify queue that these events processed
             self.task_queue.task_done()
 
-            # Put output to result queue to await being picked up by Output
-            # thread
+            # Put output to result queue to await being picked up by Output thread
             self.result_queue.put(answer)
-
-        return
 
 
 class OutputEvents(BaseProcess):
@@ -174,12 +180,13 @@ class OutputEvents(BaseProcess):
             # processed
             can_end = self.input_done.is_set() and self.process_done.is_set()
 
+            # In case of a crash, end immediately
+            if self.has_crashed.is_set():
+                break
+
             # Useful statistics
-            print('input_done:', self.input_done.is_set(),
-                  'process_done:', self.process_done.is_set(),
-                  'output_done:', self.output_done.is_set(),
-                  'blocks waiting input:', self.task_queue.qsize(),
-                  'blocks waiting output:', self.result_queue.qsize())
+            print('\rprocessing queue:', self.task_queue.qsize(),
+                  'output queue:', self.result_queue.qsize(), end="")
 
             try:
                 # Get events, or raise queue.Empty if timed out
@@ -196,11 +203,16 @@ class OutputEvents(BaseProcess):
                 # If queue is empty, and input and processing done, then exit
                 # the while loop.
                 if can_end:
-                    self.output_done.set()
-                    p.shutdown()
                     break
+            except Exception as e:
+                # Oh no, a crash! Try to get out to avoid a hang
+                self.has_crashed.set()
+                self.result_queue.task_done()
+                self.output_done.set()
+                raise e
 
-        return
+        self.output_done.set()
+        p.shutdown()
 
 
 def main():
@@ -281,7 +293,7 @@ def main():
 
     else:  # Parallel processing
         override_dict['pax']['plugin_group_names'] = ['input']
-        p = core.Processor(config_names=args.config,
+        input_pax = core.Processor(config_names=args.config,
                            config_paths=args.config_path,
                            config_dict=copy.deepcopy(override_dict))
 
@@ -291,6 +303,7 @@ def main():
         input_done = multiprocessing.Event()
         process_done = multiprocessing.Event()
         output_done = multiprocessing.Event()
+        has_crashed = multiprocessing.Event()
 
         # Establish communication queues
         tasks = multiprocessing.JoinableQueue()
@@ -298,53 +311,59 @@ def main():
 
         # Start consumers
         num_consumers = args.cpus
-        p.log.info('Creating %d consumers',
-                   num_consumers)
+        input_pax.log.info('Creating %d consumers', num_consumers)
         consumers = [ProcessorEvents(tasks, results,
-                                     input_done, process_done, output_done,
+                                     input_done, process_done, output_done, has_crashed,
                                      args.config,
                                      args.config_path,
                                      config_dict=copy.deepcopy(override_dict)) for _ in range(num_consumers)]
 
         override_dict['pax']['plugin_group_names'] = ['output']
         consumer_output = OutputEvents(tasks, results,
-                                       input_done, process_done, output_done,
+                                       input_done, process_done, output_done, has_crashed,
                                        args.config,
                                        args.config_path,
                                        config_dict=copy.deepcopy(override_dict))
 
-        # Start all worker threads
+        # Start all consumer threads
         for w in consumers + [consumer_output]:
             w.start()
 
-        # Enqueue jobs
+        # Enqueue events to the consumers in blocks of 10
+        # TODO: Make the block size configurable, and figure out a reasonable block size
         events = []
-        n = 10  # chunk in threads (TODO: what is best n?)
-
-        for event in p.get_events():
+        multiprocessing_block_size = 10
+        for event in input_pax.get_events():
+            if has_crashed.is_set():
+                print("One of the processor workers crashed: aborting further input!")
+                break
             events.append(event)
-            if len(events) > n:
+            if len(events) > multiprocessing_block_size:
                 tasks.put(events)
                 events = []
-
-        # If anything left over
         if len(events):
             tasks.put(events)
-        p.shutdown()
+        input_pax.shutdown()
 
-        # Input stage done
-        input_done.set()
-
-        # Put poison pills to tell thread to quit
+        # Finalize input
+        if has_crashed.is_set():
+            raise RuntimeError("Premature exit due to crash!")
+        # Put "poison pills" to the task queues: these tell the workers nothing more is coming and it is ok to quit
         for i in range(num_consumers):
             tasks.put(None)
+        input_done.set()
 
-        print("Wait for consumers to finish")
+        print("Input done: waiting for processing to finish")
         tasks.join()  # blocks until processing done
-
         process_done.set()  # processing done
+        if has_crashed.is_set():
+            raise RuntimeError("Premature exit due to crash!")
 
+        print("Processing done: waiting for output to finish")
         output_done.wait()  # wait until output done
+
+        if has_crashed.is_set():
+            raise RuntimeError("Premature exit due to crash!")
         print("All events processed.  Exiting...")
 
 


### PR DESCRIPTION
The multiprocessing in pax will hang if one of the processes doing the processing crashes: see #240. You can confirm this by raising an exception on purpose, e.g. at a specific event number.

This introduces some safeguards to check for such a crash, then exit loud and as soon as possible.

The status line is also changed to overwrite itself, so even if there is a hang, you'll be able to see the crash message (if there was one).
