### PR TITLE
Add metadata to root file

### DIFF
--- a/pax/plugins/io/ROOTClass.py
+++ b/pax/plugins/io/ROOTClass.py
@@ -9,6 +9,8 @@ from pax import plugin, datastructure
 import sysconfig
 import six
 import array
+import json
+
 ##
 # Build the pax event class path
 ##
@@ -94,6 +96,9 @@ class WriteROOTClass(plugin.OutputPlugin):
         self.f = ROOT.TFile(output_file, "RECREATE")
         self.f.cd()
         self.event_tree = None
+
+        # Write the metadata to the file as JSON
+        ROOT.TNamed('pax_metadata', json.dumps(self.processor.get_metadata())).Write()
 
     def write_event(self, event):
 


### PR DESCRIPTION
This adds the pax metadata (version, timestamp, config dump, etc) to the ROOTClass output in the form of a JSON string. See #286.

I followed this guide for adding a string to a ROOT file: https://root.cern.ch/phpBB3/viewtopic.php?t=3162. You can retrieve the metadata using (in python, C++ syntax should be similarish)

```
import ROOT
f = ROOT.TFile('your_file.root')
metadata_json = f.Get('pax_metadata').GetTitle()
```
