### PR TITLE
Don't use XENON100 as fallback config

### DIFF
--- a/bin/paxer
+++ b/bin/paxer
@@ -153,12 +153,12 @@ def get_args(input_plugin_aliases, output_plugin_aliases):
     # Pass in a name to use a pre-cooked config from config:
     config_options = utils.get_named_configuration_options()
     parser.add_argument('--config',
-                        default='XENON100',
                         choices=config_options,
+                        default=[],
                         nargs='+',
                         metavar='CONFIG',
-                        help="Name(s) of the pax configuration(s) to use: default is XENON100. "
-                             "Should be a space-separated list; allowed-values are: " + \
+                        help="Name(s) of the pax configuration(s) to use. "
+                             "Should be a space-separated list; allowed-values are: " +
                              ', '.join(config_options))
     # ... or a path to your own config file:
     parser.add_argument('--config_path',
@@ -198,8 +198,12 @@ def get_args(input_plugin_aliases, output_plugin_aliases):
     parser.add_argument('--version',  action='store_true',
                         help="Print current pax version, then exit")
 
-    return parser.parse_args()
+    args = parser.parse_args()
 
+    if not args.config or args.config_path:
+        print("You did not specify any configuration!")
+        parser.print_usage()
+        exit()
 
 def get_aliases():
     # Make the output plugin aliases

--- a/pax/configuration.py
+++ b/pax/configuration.py
@@ -6,8 +6,6 @@ import six
 
 from pax import units, utils
 
-FALLBACK_CONFIGURATION = 'XENON100'    # Configuration to use when none is specified
-
 
 def load_configuration(config_names=(), config_paths=(), config_string=None, config_dict=None):
     """Load pax configuration using configuration data. See the docstring of Processor for more info.
@@ -39,10 +37,7 @@ def load_configuration(config_names=(), config_paths=(), config_string=None, con
     if config_string is not None:
         config_files.append(six.StringIO(config_string))
     if len(config_files) == 0 and config_dict == {}:
-        # Load the fallback configuration
-        # Have to use print, logging is not yet setup...
-        print("WARNING: no configuration specified: loading %s config!" % FALLBACK_CONFIGURATION)
-        config_files.append(os.path.join(utils.PAX_DIR, 'config', FALLBACK_CONFIGURATION + '.ini'))
+        raise RuntimeError("You did not specify any configuration :-(")
 
     # Define an interior function for loading config files: supports recursion
     config_files_read = []


### PR DESCRIPTION
@xolotl90 observed the XENON100 configuration still gets loaded even if you don't specify it. This is because `paxer` has it as a default. There is also another condition that causes paxer to fall back to xenon100 (no config files loaded and empty config dict). While this was convenient before, it's bound to cause problems as we move more towards XENON1T.

This removes these configuration fallbacks. If you don't specify --config or --config_path, paxer will now give you

```
You did not specify any configuration!
usage: paxer [-h] [--input INPUT] [--output OUTPUT]
             [--output_type OUTPUT_TYPE [OUTPUT_TYPE ...]]
             [--input_type INPUT_TYPE] [--cpus [CPUS]] [--log LOG]
             [--config CONFIG [CONFIG ...]]
             [--config_path CONFIG_PATH [CONFIG_PATH ...]]
             [--event EVENT [EVENT ...]]
             [--event_numbers_file EVENT_NUMBERS_FILE]
             [--stop_after STOP_AFTER]
             [--plot | --plot_interactive | --plot_to_dir PLOT_TO_DIR]
             [--version]
```

This is also what you get if you just type 'paxer' without anything else (before it started processing the first 1000 events from 120402_2000 to a root file).

Some helper scripts (pax_ulite etc) may have to be modified to include --config XENON100. A few test might also fail... we'll see.
