### PR TITLE
Fixed --version argument not working.

### DIFF
--- a/bin/paxer
+++ b/bin/paxer
@@ -27,9 +27,6 @@ from pax import core, utils, formats    # flake8: noqa
 def main():
     input_plugin_aliases, output_plugin_aliases = get_aliases()
     args = get_args(input_plugin_aliases, output_plugin_aliases)
-    if args.version:
-        print(pax.__version__)
-        exit()
 
     override_dict = {'pax': {}}
 
@@ -199,6 +196,10 @@ def get_args(input_plugin_aliases, output_plugin_aliases):
                         help="Print current pax version, then exit")
 
     args = parser.parse_args()
+
+    if args.version:
+        print(pax.__version__)
+        exit()
 
     if not args.config or args.config_path:
         print("You did not specify any configuration!")


### PR DESCRIPTION
Currently, a configuration file seems to be required even when only wanting to print out the current version number:

```
$ paxer --version
You did not specify any configuration!
usage: paxer [-h] [--input INPUT] [--output OUTPUT]
             [--output_type OUTPUT_TYPE [OUTPUT_TYPE ...]]
             [--input_type INPUT_TYPE] [--cpus [CPUS]] [--log LOG]
             [--config CONFIG [CONFIG ...]]
             [--config_path CONFIG_PATH [CONFIG_PATH ...]]
             [--event EVENT [EVENT ...]]
             [--event_numbers_file EVENT_NUMBERS_FILE]
             [--stop_after STOP_AFTER]
             [--plot | --plot_interactive | --plot_to_dir PLOT_TO_DIR]
             [--version]
$
```

The reason for this is, that the command line argument parser checks for a config file before checking for the `--version` argument. This minor commit fixes this issue by moving the `--version` check directly after the line, in which the command line arguments are parsed.
