### PR TITLE
Removed string comparison which prevented pulses to be extracted from non-ZLE XED event chunks.

### DIFF
--- a/pax/plugins/io/XED.py
+++ b/pax/plugins/io/XED.py
@@ -208,13 +208,12 @@ class DecodeXED(plugin.TransformPlugin):
 
         if xed_type == 'raw':
             data = np.reshape(data, (metadata['channels'], metadata['samples_in_event']))
-            if event_proxy.data['xed_type'] == b'raw0':
-                for ch_i, chdata in enumerate(data):
-                    event.pulses.append(Pulse(
-                        channel=ch_i + 1,       # +1 as first channel is 1 in Xenon100
-                        left=0,
-                        raw_data=chdata
-                    ))
+            for ch_i, chdata in enumerate(data):
+                event.pulses.append(Pulse(
+                    channel=ch_i + 1,       # +1 as first channel is 1 in Xenon100
+                    left=0,
+                    raw_data=chdata
+                ))
 
         elif xed_type == 'zle':
             # Decompress event data into fake binary file (io.BytesIO)


### PR DESCRIPTION
Two subsequent string comparisons in the XED I/O plugin, which require the `xed_type` string to be equal to two different strings (which is impossible), prevent the extraction of pulses from non-ZLE XED files. This minor commit removes the second comparison:

``` Python
if event_proxy.data['xed_type'] == b'raw0':
```

as the correct `xed_type` value is `'raw'` for a non-ZLE XED file.
