### PR TITLE
Bump numpy requirement to 1.10.2: see #245

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 wheel>=0.23.0
-numpy>=1.9.0
+numpy>=1.10.2
 pymongo>=3.0
 matplotlib>=1.3.0
 scipy>=0.15


### PR DESCRIPTION
Numpy 1.10.1 has a speed issue that slows down pax.
