### PR TITLE
Pax cpp classes included in ROOT file

### DIFF
--- a/pax/exceptions.py
+++ b/pax/exceptions.py
@@ -9,3 +9,7 @@ class OutputFileAlreadyExistsError(Exception):
 
 class CoordinateOutOfRangeException(Exception):
     pass
+
+
+class MaybeOldFormatException(Exception):
+    pass


### PR DESCRIPTION
This fixes #320, #314 (and in a weird sense maybe also #284) by moving the pax event class inside the pax root file (in a TNamed called pax_event_class). To load the class from a root file, use

```
from pax.plugins.io import ROOTClass
ROOTClass.load_pax_event_class_from_root('your_filename.root')
```

Then open the TFile as usual. After this is merged we will change hax to do this for you of course, and provide convenience functions to load the class and open a file in one go.

Old code loading the event class separately will continue to work. For future reference, if you want to read in a pax file from before this pull request, you do:

```
from pax.plugins.io import ROOTClass
ROOTCLass.load_pax_event_class('old_pax_event_class.cpp')
```

The event class is still output to the current directory, for the benefit of C++ programmers (... and because I didn't find a way to hide it that didn't suck). Of course, you can always just extract the class from the root file, then compile it. 
## Details

When you use load_pax_event_class_from_root, it first extracts the pax event class to a file called `pax_event_class-CHECKSUM.cpp` in the current directory, where CHECKSUM is the md5 checksum of the code. Using rootpy's caching system (see http://www.rootpy.org/reference/compiled.html and www.rootpy.org/reference/stl.html), we will either compile the class and generate the appropriate dictionary libraries, or load the .so's from this step that were compiled before.

It is necessary to have the checksum in the filename to ensure the dictionary libraries are re-made for every class version. When generating a library for a dictionary (e.g. for `std::vector<Peak>`) rootpy names the library after the checksum of this:

```
unique_name = ';'.join([declaration] + headers)
```

where 'declaration' is just e.g. the string std::vector<Event>, but headers includes the line 

```
#include "whatever_our_pax_event_class_filename_is.cpp"
```

So by including a checksum in the pax event class filename, we prevent one version of the class from loading the cached libraries from another version.
