### PR TITLE
Small fixes for XENON1T processing

### DIFF
--- a/pax/config/XENON1T.ini
+++ b/pax/config/XENON1T.ini
@@ -52,7 +52,7 @@ pre_analysis = [
                 'ClassifyPeaks.GasXenonZeroFieldClassification',
 
                 # Do 3d posrec on the S1s (would like to do this earlier on all peaks, but performance...)
-                'ThreeDPatternFit.PosRecThreeDPatternFit',
+                # 'ThreeDPatternFit.PosRecThreeDPatternFit',
 
                 # Combine S1 and S2 into pairs = interactions and compute properties
                 # which depend on S1 AND S2 specific information (i.e. z-corrections)
@@ -106,6 +106,7 @@ buffer_size = 10
 [CheckPulses.CheckBounds]
 
 truncate_pulses_partially_outside = True
+allow_pulse_completely_outside = True    # If True, and truncation is True, will remove the pulses rather than error
 
 [WaveformSimulator.WaveformSimulatorFromCSV]
 input_name =                          'dummy_waveforms_1t.csv'

--- a/pax/core.py
+++ b/pax/core.py
@@ -79,7 +79,7 @@ class Processor:
             self.input_queue = pc['input_queue']
             self.output_queue = pc.get('output_queue', None)
             # Remove multiprocessing objects from config datastructure,
-            # so it can be serialized later
+            # so the configuration can still be serialized to JSON later
             for k in ['input_queue', 'output_queue', 'status']:
                 pc[k] = None
 

--- a/pax/plugins/io/ROOTClass.py
+++ b/pax/plugins/io/ROOTClass.py
@@ -373,18 +373,19 @@ def load_event_class_code(class_code, other_process_compiles=False):
     libfile = get_libname(class_filename)
 
     if other_process_compiles:
+        # TODO: use file locks instead, timers are unreliable
         while not os.path.exists(libfile):
             log.debug("Waiting for another process to compile the pax event class")
             time.sleep(5)
         log.info("Compiled pax event class has been found, "
-                 "sleeping 10 sec to ensure compilation and dictionary generation have finished")
-        time.sleep(10)
+                 "sleeping 20 sec to ensure compilation and dictionary generation have finished")
+        time.sleep(20)
     else:
         with open(class_filename, mode='w') as outfile:
             outfile.write(class_code)
 
-        # Compile the class (or decide we don't have to)
-        load_event_class(os.path.abspath(class_filename))
+    # Compile the class (or decide we don't have to)
+    load_event_class(os.path.abspath(class_filename))
 
 
 def load_event_class(filename, force_recompile=False):


### PR DESCRIPTION
This includes a few small fixes for processing XENON1T data:

 * "Fix" (in a very dirty way) a race condition in the ROOT output during multiprocessing, where several threads tried to write and/or compile the event class cpp file at the same time;
 * Turn off 3d posrec for now, it's nonsense in gas (LCE map for liquid) anyway, and it slows the processing  by a factor 5-10.
 * Don't crash if pulses are completely outside the event . This indicates there is still (probably) an off-by-one error in the event builder... I though this protection was enabled before, but it probably got lost.