### PR TITLE
G4 Optical - FAX interface updated. Fix one bug about the simulated p…

### DIFF
--- a/pax/simulation.py
+++ b/pax/simulation.py
@@ -263,9 +263,11 @@ class Simulator(object):
                             len(generated_pulse), left_index, righter_index))
                 elif left_index < 0:
                     self.log.debug("Invalid left index %s: can't be negative" % left_index)
+                    continue
                 elif righter_index >= len(current_wave):
                     self.log.debug("Invalid right index %s: can't be longer than length of wave (%s)!" % (
                         right_index, len(current_wave)))
+                    continue
 
                 current_wave[left_index: righter_index] += generated_pulse
 

--- a/pax/simulation.py
+++ b/pax/simulation.py
@@ -258,11 +258,14 @@ class Simulator(object):
 
                 # Abandon the pulse if it goes the left/right boundaries
                 if len(generated_pulse) != righter_index - left_index:
-                    continue
+                    raise RuntimeError(
+                        "Generated pulse is %s samples long, can't be inserted between %s and %s" % (
+                            len(generated_pulse), left_index, righter_index))
                 elif left_index < 0:
-                    continue
+                    self.log.debug("Invalid left index %s: can't be negative" % left_index)
                 elif righter_index >= len(current_wave):
-                    continue
+                    self.log.debug("Invalid right index %s: can't be longer than length of wave (%s)!" % (
+                        right_index, len(current_wave)))
 
                 current_wave[left_index: righter_index] += generated_pulse
 

--- a/pax/simulation.py
+++ b/pax/simulation.py
@@ -264,9 +264,9 @@ class Simulator(object):
                 elif left_index < 0:
                     self.log.debug("Invalid left index %s: can't be negative" % left_index)
                     continue
-                elif right_index >= len(current_wave):
+                elif righter_index >= len(current_wave):
                     self.log.debug("Invalid right index %s: can't be longer than length of wave (%s)!" % (
-                        right_index, len(current_wave)))
+                        righter_index, len(current_wave)))
                     continue
 
                 current_wave[left_index: righter_index] += generated_pulse

--- a/pax/simulation.py
+++ b/pax/simulation.py
@@ -264,7 +264,7 @@ class Simulator(object):
                 elif left_index < 0:
                     self.log.debug("Invalid left index %s: can't be negative" % left_index)
                     continue
-                elif righter_index >= len(current_wave):
+                elif right_index >= len(current_wave):
                     self.log.debug("Invalid right index %s: can't be longer than length of wave (%s)!" % (
                         right_index, len(current_wave)))
                     continue

--- a/pax/simulation.py
+++ b/pax/simulation.py
@@ -256,18 +256,13 @@ class Simulator(object):
                 righter_index = center_index[i] - start_index + 1
                 righter_index += int(self.config['samples_after_pulse_center'])
 
-                # Debugging stuff
+                # Abandon the pulse if it goes the left/right boundaries
                 if len(generated_pulse) != righter_index - left_index:
-                    raise RuntimeError(
-                        "Generated pulse is %s samples long, can't be inserted between %s and %s" % (
-                            len(generated_pulse), left_index, righter_index))
-
-                if left_index < 0:
-                    raise RuntimeError("Invalid left index %s: can't be negative!" % left_index)
-
-                if righter_index >= len(current_wave):
-                    raise RuntimeError("Invalid right index %s: can't be longer than length of wave (%s)!" % (
-                        righter_index, len(current_wave)))
+                    continue
+                elif left_index < 0:
+                    continue
+                elif righter_index >= len(current_wave):
+                    continue
 
                 current_wave[left_index: righter_index] += generated_pulse
 


### PR DESCRIPTION
Fabio reported the error showed up when trying to use fax-g4 optical interface to process 5000-event MC file. The major error message 


  File "/home/fabiovalerio/anaconda3/envs/pax/lib/python3.4/site-packages/pax/simulation.py", line 270, in make_pax_event
    righter_index, len(current_wave)))


I went to investigate that and found a bug in the fax. In short, the PMT after pulses are generated after the simulated event's time window is defined by the photons produced by S1, S2 and S2 after pulses. Therefore if the PMT after pulse is out of the right boundary of the event window, it raises an error message. This happens very rarely, but once it happens it stops the process. So for simulating large amount of waveforms, this is a bug need to be fixed. 

For fixing it, I simply abandoned the PMT after pulses if it is out of the event window.