### PR TITLE
Fixed a case of the FaX physics backend trying to use a non-existing logger.

### DIFF
--- a/pax/simulation.py
+++ b/pax/simulation.py
@@ -262,10 +262,10 @@ class Simulator(object):
                         "Generated pulse is %s samples long, can't be inserted between %s and %s" % (
                             len(generated_pulse), left_index, righter_index))
                 elif left_index < 0:
-                    self.log.debug("Invalid left index %s: can't be negative" % left_index)
+                    log.debug("Invalid left index %s: can't be negative" % left_index)
                     continue
                 elif righter_index >= len(current_wave):
-                    self.log.debug("Invalid right index %s: can't be longer than length of wave (%s)!" % (
+                    log.debug("Invalid right index %s: can't be longer than length of wave (%s)!" % (
                         righter_index, len(current_wave)))
                     continue
 


### PR DESCRIPTION
A small fix for a bug I encountered while playing around with FaX (if indeed the simulation module logger is to be used).