### PR TITLE
Implemented a new 'LED' recoil type.

### DIFF
--- a/pax/config/XENON100.ini
+++ b/pax/config/XENON100.ini
@@ -242,7 +242,7 @@ pmt_fall_time             =           6.7 * ns           # PLACEHOLDER - Can't f
     # Guillaume's fadc.py / spe.py has 4ns as the RC time for the digitizer, so not a big effect?
 
 # LED parameters
-led_pulse_length          =           4 * us             # Pulse width corresponds to the XENON100 LED calibration one given in Alexander Kish's thesis (http://jinst.sissa.it/jinst/theses/2015_JINST_TH_005.pdf)
+led_pulse_length          =           3 * us             # Pulse width corresponds to the XENON100 LED calibration one given by Payam
 
 # Currently only used for s1 time structure calculations:
 drift_field =                         530 * V /cm        # TODO add ref ('The xenon100 experiment'?)

--- a/pax/config/XENON100.ini
+++ b/pax/config/XENON100.ini
@@ -241,6 +241,9 @@ pmt_fall_time             =           6.7 * ns           # PLACEHOLDER - Can't f
     # Note this pmt pulse shape is probably not accurate, even besides the uncertain parameters, the amplifier & digitizer also shape the pulse.
     # Guillaume's fadc.py / spe.py has 4ns as the RC time for the digitizer, so not a big effect?
 
+# LED parameters
+led_pulse_length          =           4 * us             # Pulse width corresponds to the XENON100 LED calibration one given in Alexander Kish's thesis (http://jinst.sissa.it/jinst/theses/2015_JINST_TH_005.pdf)
+
 # Currently only used for s1 time structure calculations:
 drift_field =                         530 * V /cm        # TODO add ref ('The xenon100 experiment'?)
 liquid_density =                      3 * g / cm**3      # PLACEHOLDER

--- a/pax/config/XENON1T.ini
+++ b/pax/config/XENON1T.ini
@@ -135,6 +135,9 @@ pmt_transit_time_spread   =           8.5 * ns           # https://xecluster.lng
 pmt_rise_time             =           3.0 * ns           # Daniel Mayani with scope
 pmt_fall_time             =           10.0 * ns          # Daniel Mayani with scope
 
+# LED parameters
+led_pulse_length          =           100 * ns           # Pulse width corresponds to fast pulse calibration setting from xenon:xenon1t:cal:pulse-genrator:bnc505-commands
+
 # Currently only used for s1 time structure calculations:
 drift_field =                         500 * V /cm        # Monte Carlo paper draft: "about 500 V/cm"
 liquid_density =                      3 * g / cm**3      # PLACEHOLDER

--- a/pax/simulation.py
+++ b/pax/simulation.py
@@ -429,8 +429,14 @@ class Simulator(object):
                 singlet_ratio=self.config['s1_ER_alpha_singlet_fraction']
             )
 
+        elif recoil_type.lower() == 'led':
+
+            # distribute photons uniformly within the LED pulse length
+            timings = np.random.uniform(0, self.config['led_pulse_length'],
+                                        size=n_photons)
+
         else:
-            raise ValueError('Recoil type must be ER, NR or alpha, not %s' % type)
+            raise ValueError('Recoil type must be ER, NR, alpha or LED, not %s' % type)
 
         return timings + t * np.ones(len(timings))
 


### PR DESCRIPTION
Photons are emitted uniformly within a configurable time interval instead of following excimer decay time distributions, resulting in an LED-like light source.

This addition is motivated by making PMT afterpulse measurement simulations possible with FaX. If needed, a better LED simulation could be achieved in the future by dedicated measurements of the LED hit time distribution ([similar to Jelle's hitfinder calibration note][1]).

[1]: https://xecluster.lngs.infn.it/dokuwiki/doku.php?id=xenon:xenon100:analysis:led_pax#when_does_the_led_fire