### PR TITLE
Fixes/additions to PMT map in ini

### DIFF
--- a/pax/config/XENON1T.ini
+++ b/pax/config/XENON1T.ini
@@ -587,12 +587,12 @@ gains = [
     5700000.000,    # 245 = KB0841
     5100000.000,    # 246 = KB0834
     6100000.000,    # 247 = KB0823
-    4.8e6,    # 248, placeholder (serial number not known)
-    4.8e6,    # 249, placeholder (serial number not known)
-    4.8e6,    # 250, placeholder (serial number not known)
-    4.8e6,    # 251, placeholder (serial number not known)
-    4.8e6,    # 252, placeholder (serial number not known)
-    4.8e6,    # 253, placeholder (serial number not known)
+    2e6,    # 248, placeholder: 1-inch XENON100 PMT
+    2e6,    # 249, placeholder: 1-inch XENON100 PMT
+    2e6,    # 250, placeholder: 1-inch XENON100 PMT
+    2e6,    # 251, placeholder: 1-inch XENON100 PMT
+    2e6,    # 252, placeholder: 1-inch XENON100 PMT
+    2e6,    # 253, placeholder: 1-inch XENON100 PMT
     ]
 
 gain_sigmas = [1e6] * 254                          # PLACEHOLDER
@@ -861,1781 +861,6609 @@ relative_qe_error = 0.02                           # PLACEHOLDER
 relative_gain_error = 0.03                         # PLACEHOLDER
 
 # "Static" PMT info (stuff that doesn't need to be calibrated and won't change unless somebody makes a hardware change)
-pmts = [{'array': 'top',
-          'digitizer': {'channel': 3, 'crate': 0, 'module': 1244, 'slot': 10},
-          'high_voltage': {'connector': '3.05', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 0,
-          'position': {'x': -12.345668451390225, 'y': 46.074661913988564},
-          'serial_number': 511.0,
-          'signal': {'connector': '3.05', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 2, 'crate': 0, 'module': 153, 'slot': 5},
-          'high_voltage': {'connector': '5.0', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 1,
-          'position': {'x': -4.157328929063286, 'y': 47.518487098976266},
-          'serial_number': 602.0,
-          'signal': {'connector': '5.0', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 0, 'module': 1239, 'slot': 6},
-          'high_voltage': {'connector': '5.01', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 2,
-          'position': {'x': 4.1573289290632935, 'y': 47.51848709897626},
-          'serial_number': 513.0,
-          'signal': {'connector': '5.01', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 3, 'crate': 0, 'module': 1239, 'slot': 6},
-          'high_voltage': {'connector': '5.02', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 3,
-          'position': {'x': 12.345668451390232, 'y': 46.07466191398856},
-          'serial_number': 479.0,
-          'signal': {'connector': '5.02', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 0, 'module': 154, 'slot': 7},
-          'high_voltage': {'connector': '5.03', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 4,
-          'position': {'x': 20.158891085031385, 'y': 43.230881441648194},
-          'serial_number': 519.0,
-          'signal': {'connector': '5.03', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 0, 'module': 153, 'slot': 5},
-          'high_voltage': {'connector': '5.04', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 5,
-          'position': {'x': 27.35959601394491, 'y': 39.073552512584904},
-          'serial_number': 419.0,
-          'signal': {'connector': '5.04', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 0, 'crate': 0, 'module': 154, 'slot': 7},
-          'high_voltage': {'connector': '5.05', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 6,
-          'position': {'x': 33.72899346259835, 'y': 33.72899346259829},
-          'serial_number': 779.0,
-          'signal': {'connector': '5.05', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 1, 'crate': 1, 'module': 1258, 'slot': 16},
-          'high_voltage': {'connector': '0.0', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 7,
-          'position': {'x': 39.073552512584904, 'y': 27.359596013944902},
-          'serial_number': 496.0,
-          'signal': {'connector': '0.0', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 1, 'crate': 1, 'module': 1257, 'slot': 14},
-          'high_voltage': {'connector': '0.01', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 8,
-          'position': {'x': 43.23088144164822, 'y': 20.158891085031343},
-          'serial_number': 877.0,
-          'signal': {'connector': '0.01', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 1, 'crate': 1, 'module': 1229, 'slot': 15},
-          'high_voltage': {'connector': '0.02', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 9,
-          'position': {'x': 46.074661913988564, 'y': 12.345668451390226},
-          'serial_number': 885.0,
-          'signal': {'connector': '0.02', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 0, 'crate': 1, 'module': 1258, 'slot': 16},
-          'high_voltage': {'connector': '0.03', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 10,
-          'position': {'x': 47.518487098976266, 'y': 4.157328929063288},
-          'serial_number': 469.0,
-          'signal': {'connector': '0.03', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 2, 'crate': 1, 'module': 1257, 'slot': 14},
-          'high_voltage': {'connector': '0.04', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 11,
-          'position': {'x': 47.51848709897626, 'y': -4.157328929063292},
-          'serial_number': 140.0,
-          'signal': {'connector': '0.04', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 4, 'crate': 1, 'module': 1229, 'slot': 15},
-          'high_voltage': {'connector': '0.05', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 12,
-          'position': {'x': 46.07466191398855, 'y': -12.34566845139027},
-          'serial_number': 432.0,
-          'signal': {'connector': '0.05', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 1, 'module': 1161, 'slot': 3},
-          'high_voltage': {'connector': '2.0', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 13,
-          'position': {'x': 43.230881441648194, 'y': -20.158891085031378},
-          'serial_number': 634.0,
-          'signal': {'connector': '2.0', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 1, 'module': 1187, 'slot': 7},
-          'high_voltage': {'connector': '2.01', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 14,
-          'position': {'x': 39.07355251258489, 'y': -27.359596013944923},
-          'serial_number': 413.0,
-          'signal': {'connector': '2.01', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 1, 'module': 1212, 'slot': 5},
-          'high_voltage': {'connector': '2.02', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 15,
-          'position': {'x': 33.72899346259832, 'y': -33.72899346259832},
-          'serial_number': 538.0,
-          'signal': {'connector': '2.02', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 6, 'crate': 1, 'module': 1161, 'slot': 3},
-          'high_voltage': {'connector': '2.03', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 16,
-          'position': {'x': 27.35959601394489, 'y': -39.07355251258491},
-          'serial_number': 915.0,
-          'signal': {'connector': '2.03', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 6, 'crate': 1, 'module': 1212, 'slot': 5},
-          'high_voltage': {'connector': '2.04', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 17,
-          'position': {'x': 20.158891085031346, 'y': -43.23088144164822},
-          'serial_number': 535.0,
-          'signal': {'connector': '2.04', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 6, 'crate': 1, 'module': 1187, 'slot': 7},
-          'high_voltage': {'connector': '2.05', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 18,
-          'position': {'x': 12.34566845139023, 'y': -46.074661913988564},
-          'serial_number': 531.0,
-          'signal': {'connector': '2.05', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 7, 'crate': 0, 'module': 1242, 'slot': 8},
-          'high_voltage': {'connector': '4.0', 'feedthrough': 1, 'return': 4},
-          'pmt_position': 19,
-          'position': {'x': 4.157328929063292, 'y': -47.518487098976266},
-          'serial_number': 447.0,
-          'signal': {'connector': '4.0', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 7, 'crate': 0, 'module': 156, 'slot': 9},
-          'high_voltage': {'connector': '4.01', 'feedthrough': 1, 'return': 4},
-          'pmt_position': 20,
-          'position': {'x': -4.1573289290633095, 'y': -47.51848709897626},
-          'serial_number': 444.0,
-          'signal': {'connector': '4.01', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 7, 'crate': 0, 'module': 154, 'slot': 7},
-          'high_voltage': {'connector': '4.02', 'feedthrough': 1, 'return': 4},
-          'pmt_position': 21,
-          'position': {'x': -12.345668451390264, 'y': -46.07466191398856},
-          'serial_number': 579.0,
-          'signal': {'connector': '4.02', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 7, 'crate': 0, 'module': 1239, 'slot': 6},
-          'high_voltage': {'connector': '4.03', 'feedthrough': 1, 'return': 4},
-          'pmt_position': 22,
-          'position': {'x': -20.158891085031378, 'y': -43.230881441648194},
-          'serial_number': 611.0,
-          'signal': {'connector': '4.03', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 7, 'crate': 0, 'module': 153, 'slot': 5},
-          'high_voltage': {'connector': '4.04', 'feedthrough': 1, 'return': 4},
-          'pmt_position': 23,
-          'position': {'x': -27.359596013944902, 'y': -39.07355251258491},
-          'serial_number': 614.0,
-          'signal': {'connector': '4.04', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 0, 'crate': 0, 'module': 1242, 'slot': 8},
-          'high_voltage': {'connector': '4.05', 'feedthrough': 1, 'return': 4},
-          'pmt_position': 24,
-          'position': {'x': -33.728993462598325, 'y': -33.728993462598304},
-          'serial_number': 553.0,
-          'signal': {'connector': '4.05', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 0, 'crate': 1, 'module': 1227, 'slot': 13},
-          'high_voltage': {'connector': '1.0', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 25,
-          'position': {'x': -39.07355251258492, 'y': -27.359596013944888},
-          'serial_number': 764.0,
-          'signal': {'connector': '1.0', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 1, 'crate': 1, 'module': 1227, 'slot': 13},
-          'high_voltage': {'connector': '1.01', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 26,
-          'position': {'x': -43.23088144164821, 'y': -20.158891085031357},
-          'serial_number': 149.0,
-          'signal': {'connector': '1.01', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 1, 'crate': 1, 'module': 1219, 'slot': 11},
-          'high_voltage': {'connector': '1.02', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 27,
-          'position': {'x': -46.074661913988564, 'y': -12.345668451390232},
-          'serial_number': 509.0,
-          'signal': {'connector': '1.02', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 2, 'crate': 1, 'module': 1227, 'slot': 13},
-          'high_voltage': {'connector': '1.03', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 28,
-          'position': {'x': -47.518487098976266, 'y': -4.157328929063286},
-          'serial_number': 524.0,
-          'signal': {'connector': '1.03', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 4, 'crate': 1, 'module': 1254, 'slot': 12},
-          'high_voltage': {'connector': '1.04', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 29,
-          'position': {'x': -47.51848709897626, 'y': 4.157328929063306},
-          'serial_number': 527.0,
-          'signal': {'connector': '1.04', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 4, 'crate': 1, 'module': 1219, 'slot': 11},
-          'high_voltage': {'connector': '1.05', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 30,
-          'position': {'x': -46.07466191398856, 'y': 12.345668451390251},
-          'serial_number': 545.0,
-          'signal': {'connector': '1.05', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 0, 'crate': 0, 'module': 876, 'slot': 11},
-          'high_voltage': {'connector': '3.0', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 31,
-          'position': {'x': -43.2308814416482, 'y': 20.15889108503137},
-          'serial_number': 508.0,
-          'signal': {'connector': '3.0', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 0, 'crate': 0, 'module': 1244, 'slot': 10},
-          'high_voltage': {'connector': '3.01', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 32,
-          'position': {'x': -39.073552512584904, 'y': 27.359596013944902},
-          'serial_number': 471.0,
-          'signal': {'connector': '3.01', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 2, 'crate': 0, 'module': 876, 'slot': 11},
-          'high_voltage': {'connector': '3.02', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 33,
-          'position': {'x': -33.72899346259831, 'y': 33.72899346259832},
-          'serial_number': 529.0,
-          'signal': {'connector': '3.02', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 1, 'crate': 0, 'module': 1244, 'slot': 10},
-          'high_voltage': {'connector': '3.03', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 34,
-          'position': {'x': -27.359596013944895, 'y': 39.07355251258491},
-          'serial_number': 547.0,
-          'signal': {'connector': '3.03', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 7, 'crate': 0, 'module': 1246, 'slot': 12},
-          'high_voltage': {'connector': '3.04', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 35,
-          'position': {'x': -20.158891085031357, 'y': 43.23088144164821},
-          'serial_number': 830.0,
-          'signal': {'connector': '3.04', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 0, 'module': 1244, 'slot': 10},
-          'high_voltage': {'connector': '3.10', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 36,
-          'position': {'x': -10.288057042825152, 'y': 38.39555159499048},
-          'serial_number': 428.0,
-          'signal': {'connector': '3.10', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 6, 'crate': 0, 'module': 1244, 'slot': 10},
-          'high_voltage': {'connector': '3.11', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 37,
-          'position': {'x': -2.0803542606570264, 'y': 39.69552400649432},
-          'serial_number': 745.0,
-          'signal': {'connector': '3.11', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 0, 'crate': 0, 'module': 153, 'slot': 5},
-          'high_voltage': {'connector': '5.06', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 38,
-          'position': {'x': 6.218269985349179, 'y': 39.260611538656725},
-          'serial_number': 826.0,
-          'signal': {'connector': '5.06', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 0, 'crate': 0, 'module': 1239, 'slot': 6},
-          'high_voltage': {'connector': '5.07', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 39,
-          'position': {'x': 14.245125994425699, 'y': 37.10982195326377},
-          'serial_number': 832.0,
-          'signal': {'connector': '5.07', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 1, 'crate': 0, 'module': 1239, 'slot': 6},
-          'high_voltage': {'connector': '5.08', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 40,
-          'position': {'x': 21.64940164184732, 'y': 33.33715507583061},
-          'serial_number': 598.0,
-          'signal': {'connector': '5.08', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 1, 'crate': 0, 'module': 154, 'slot': 7},
-          'high_voltage': {'connector': '5.09', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 41,
-          'position': {'x': 28.107494552165267, 'y': 28.107494552165264},
-          'serial_number': 455.0,
-          'signal': {'connector': '5.09', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 3, 'crate': 1, 'module': 1257, 'slot': 14},
-          'high_voltage': {'connector': '0.06', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 42,
-          'position': {'x': 33.33715507583061, 'y': 21.649401641847316},
-          'serial_number': 153.0,
-          'signal': {'connector': '0.06', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 4, 'crate': 1, 'module': 1257, 'slot': 14},
-          'high_voltage': {'connector': '0.07', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 43,
-          'position': {'x': 37.10982195326378, 'y': 14.245125994425663},
-          'serial_number': 448.0,
-          'signal': {'connector': '0.07', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 1, 'module': 1229, 'slot': 15},
-          'high_voltage': {'connector': '0.08', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 44,
-          'position': {'x': 39.26061153865673, 'y': 6.218269985349142},
-          'serial_number': 211.0,
-          'signal': {'connector': '0.08', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 1, 'module': 1257, 'slot': 14},
-          'high_voltage': {'connector': '0.09', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 45,
-          'position': {'x': 39.6955240064943, 'y': -2.080354260657028},
-          'serial_number': 506.0,
-          'signal': {'connector': '0.09', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 6, 'crate': 1, 'module': 1258, 'slot': 16},
-          'high_voltage': {'connector': '0.10', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 46,
-          'position': {'x': 38.39555159499045, 'y': -10.288057042825226},
-          'serial_number': 417.0,
-          'signal': {'connector': '0.10', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 7, 'crate': 1, 'module': 1212, 'slot': 5},
-          'high_voltage': {'connector': '2.06', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 47,
-          'position': {'x': 35.41750933648761, 'y': -18.046122364647005},
-          'serial_number': 549.0,
-          'signal': {'connector': '2.06', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 7, 'crate': 1, 'module': 1161, 'slot': 3},
-          'high_voltage': {'connector': '2.07', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 48,
-          'position': {'x': 30.891551967914587, 'y': -25.01548554423105},
-          'serial_number': 667.0,
-          'signal': {'connector': '2.07', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 4, 'crate': 1, 'module': 1187, 'slot': 7},
-          'high_voltage': {'connector': '2.08', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 49,
-          'position': {'x': 25.015485544231034, 'y': -30.8915519679146},
-          'serial_number': 790.0,
-          'signal': {'connector': '2.08', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 1, 'module': 1249, 'slot': 4},
-          'high_voltage': {'connector': '2.09', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 50,
-          'position': {'x': 18.04612236464697, 'y': -35.41750933648763},
-          'serial_number': 824.0,
-          'signal': {'connector': '2.09', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 1, 'module': 1250, 'slot': 6},
-          'high_voltage': {'connector': '2.10', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 51,
-          'position': {'x': 10.288057042825173, 'y': -38.39555159499047},
-          'serial_number': 825.0,
-          'signal': {'connector': '2.10', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 6, 'crate': 1, 'module': 1249, 'slot': 4},
-          'high_voltage': {'connector': '2.11', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 52,
-          'position': {'x': 2.080354260657014, 'y': -39.69552400649432},
-          'serial_number': 507.0,
-          'signal': {'connector': '2.11', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 1, 'crate': 0, 'module': 1242, 'slot': 8},
-          'high_voltage': {'connector': '4.06', 'feedthrough': 1, 'return': 4},
-          'pmt_position': 53,
-          'position': {'x': -6.218269985349176, 'y': -39.260611538656725},
-          'serial_number': 530.0,
-          'signal': {'connector': '4.06', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 2, 'crate': 0, 'module': 1242, 'slot': 8},
-          'high_voltage': {'connector': '4.07', 'feedthrough': 1, 'return': 4},
-          'pmt_position': 54,
-          'position': {'x': -14.245125994425695, 'y': -37.10982195326377},
-          'serial_number': 795.0,
-          'signal': {'connector': '4.07', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 4, 'crate': 0, 'module': 156, 'slot': 9},
-          'high_voltage': {'connector': '4.08', 'feedthrough': 1, 'return': 4},
-          'pmt_position': 55,
-          'position': {'x': -21.64940164184734, 'y': -33.337155075830594},
-          'serial_number': 421.0,
-          'signal': {'connector': '4.08', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 3, 'crate': 0, 'module': 156, 'slot': 9},
-          'high_voltage': {'connector': '4.09', 'feedthrough': 1, 'return': 4},
-          'pmt_position': 56,
-          'position': {'x': -28.10749455216527, 'y': -28.107494552165253},
-          'serial_number': 813.0,
-          'signal': {'connector': '4.09', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 6, 'crate': 1, 'module': 1254, 'slot': 12},
-          'high_voltage': {'connector': '1.06', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 57,
-          'position': {'x': -33.33715507583061, 'y': -21.64940164184732},
-          'serial_number': 472.0,
-          'signal': {'connector': '1.06', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 1, 'module': 1254, 'slot': 12},
-          'high_voltage': {'connector': '1.07', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 58,
-          'position': {'x': -37.109821953263776, 'y': -14.245125994425678},
-          'serial_number': 487.0,
-          'signal': {'connector': '1.07', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 0, 'crate': 1, 'module': 1219, 'slot': 11},
-          'high_voltage': {'connector': '1.08', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 59,
-          'position': {'x': -39.260611538656725, 'y': -6.218269985349172},
-          'serial_number': 564.0,
-          'signal': {'connector': '1.08', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 1, 'crate': 1, 'module': 1254, 'slot': 12},
-          'high_voltage': {'connector': '1.09', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 60,
-          'position': {'x': -39.6955240064943, 'y': 2.080354260657023},
-          'serial_number': 610.0,
-          'signal': {'connector': '1.09', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 2, 'crate': 1, 'module': 1219, 'slot': 11},
-          'high_voltage': {'connector': '1.10', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 61,
-          'position': {'x': -38.395551594990465, 'y': 10.288057042825208},
-          'serial_number': 655.0,
-          'signal': {'connector': '1.10', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 0, 'module': 876, 'slot': 11},
-          'high_voltage': {'connector': '3.06', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 62,
-          'position': {'x': -35.41750933648762, 'y': 18.04612236464699},
-          'serial_number': 665.0,
-          'signal': {'connector': '3.06', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 4, 'crate': 0, 'module': 1244, 'slot': 10},
-          'high_voltage': {'connector': '3.07', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 63,
-          'position': {'x': -30.891551967914587, 'y': 25.01548554423104},
-          'serial_number': 856.0,
-          'signal': {'connector': '3.07', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 7, 'crate': 0, 'module': 1243, 'slot': 13},
-          'high_voltage': {'connector': '3.08', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 64,
-          'position': {'x': -25.015485544231034, 'y': 30.8915519679146},
-          'serial_number': 829.0,
-          'signal': {'connector': '3.08', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 6, 'crate': 0, 'module': 1246, 'slot': 12},
-          'high_voltage': {'connector': '3.09', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 65,
-          'position': {'x': -18.04612236464698, 'y': 35.41750933648763},
-          'serial_number': 544.0,
-          'signal': {'connector': '3.09', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 3, 'crate': 0, 'module': 876, 'slot': 11},
-          'high_voltage': {'connector': '3.15', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 66,
-          'position': {'x': -8.23044563426015, 'y': 30.716441275992377},
-          'serial_number': 683.0,
-          'signal': {'connector': '3.15', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 2, 'crate': 0, 'module': 156, 'slot': 9},
-          'high_voltage': {'connector': '3.16', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 67,
-          'position': {'x': 3.108624468950438e-14, 'y': 31.8},
-          'serial_number': 712.0,
-          'signal': {'connector': '3.16', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 1, 'crate': 0, 'module': 153, 'slot': 5},
-          'high_voltage': {'connector': '5.10', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 68,
-          'position': {'x': 8.230445634260182, 'y': 30.716441275992366},
-          'serial_number': 851.0,
-          'signal': {'connector': '5.10', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 2, 'crate': 0, 'module': 1239, 'slot': 6},
-          'high_voltage': {'connector': '5.11', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 69,
-          'position': {'x': 15.90000000000001, 'y': 27.53960784034514},
-          'serial_number': 831.0,
-          'signal': {'connector': '5.11', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 6, 'crate': 1, 'module': 1229, 'slot': 15},
-          'high_voltage': {'connector': '0.11', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 70,
-          'position': {'x': 22.485995641732213, 'y': 22.485995641732213},
-          'serial_number': 771.0,
-          'signal': {'connector': '0.11', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 6, 'crate': 1, 'module': 1257, 'slot': 14},
-          'high_voltage': {'connector': '0.12', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 71,
-          'position': {'x': 27.53960784034516, 'y': 15.899999999999984},
-          'serial_number': 794.0,
-          'signal': {'connector': '0.12', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 7, 'crate': 1, 'module': 1257, 'slot': 14},
-          'high_voltage': {'connector': '0.13', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 72,
-          'position': {'x': 30.716441275992374, 'y': 8.230445634260152},
-          'serial_number': 150.0,
-          'signal': {'connector': '0.13', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 7, 'crate': 1, 'module': 1258, 'slot': 16},
-          'high_voltage': {'connector': '0.14', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 73,
-          'position': {'x': 31.8, 'y': 0.0},
-          'serial_number': 269.0,
-          'signal': {'connector': '0.14', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 7, 'crate': 1, 'module': 1229, 'slot': 15},
-          'high_voltage': {'connector': '0.15', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 74,
-          'position': {'x': 30.716441275992366, 'y': -8.230445634260182},
-          'serial_number': 711.0,
-          'signal': {'connector': '0.15', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 6, 'crate': 1, 'module': 1250, 'slot': 6},
-          'high_voltage': {'connector': '2.12', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 75,
-          'position': {'x': 27.539607840345138, 'y': -15.90000000000002},
-          'serial_number': 811.0,
-          'signal': {'connector': '2.12', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 7, 'crate': 1, 'module': 1249, 'slot': 4},
-          'high_voltage': {'connector': '2.13', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 76,
-          'position': {'x': 22.485995641732202, 'y': -22.485995641732224},
-          'serial_number': 917.0,
-          'signal': {'connector': '2.13', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 6, 'crate': 0, 'module': 1234, 'slot': 16},
-          'high_voltage': {'connector': '2.14', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 77,
-          'position': {'x': 15.899999999999999, 'y': -27.539607840345152},
-          'serial_number': 883.0,
-          'signal': {'connector': '2.14', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 0, 'crate': 0, 'module': 110, 'slot': 15},
-          'high_voltage': {'connector': '2.15', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 78,
-          'position': {'x': 8.230445634260153, 'y': -30.716441275992374},
-          'serial_number': 649.0,
-          'signal': {'connector': '2.15', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 2, 'crate': 0, 'module': 1234, 'slot': 16},
-          'high_voltage': {'connector': '2.16', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 79,
-          'position': {'x': -1.3322676295501878e-14, 'y': -31.8},
-          'serial_number': 708.0,
-          'signal': {'connector': '2.16', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 3, 'crate': 0, 'module': 1242, 'slot': 8},
-          'high_voltage': {'connector': '4.10', 'feedthrough': 1, 'return': 4},
-          'pmt_position': 80,
-          'position': {'x': -8.230445634260162, 'y': -30.716441275992374},
-          'serial_number': 766.0,
-          'signal': {'connector': '4.10', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 0, 'module': 156, 'slot': 9},
-          'high_voltage': {'connector': '4.11', 'feedthrough': 1, 'return': 4},
-          'pmt_position': 81,
-          'position': {'x': -15.900000000000006, 'y': -27.539607840345145},
-          'serial_number': 814.0,
-          'signal': {'connector': '4.11', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 2, 'crate': 1, 'module': 1254, 'slot': 12},
-          'high_voltage': {'connector': '1.11', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 82,
-          'position': {'x': -22.485995641732217, 'y': -22.485995641732202},
-          'serial_number': 812.0,
-          'signal': {'connector': '1.11', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 1, 'module': 1227, 'slot': 13},
-          'high_voltage': {'connector': '1.12', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 83,
-          'position': {'x': -27.539607840345152, 'y': -15.899999999999993},
-          'serial_number': 928.0,
-          'signal': {'connector': '1.12', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 1, 'module': 1219, 'slot': 11},
-          'high_voltage': {'connector': '1.13', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 84,
-          'position': {'x': -30.716441275992374, 'y': -8.230445634260155},
-          'serial_number': 213.0,
-          'signal': {'connector': '1.13', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 6, 'crate': 1, 'module': 1227, 'slot': 13},
-          'high_voltage': {'connector': '1.14', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 85,
-          'position': {'x': -31.8, 'y': 3.552713678800501e-15},
-          'serial_number': 546.0,
-          'signal': {'connector': '1.14', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 7, 'crate': 1, 'module': 1227, 'slot': 13},
-          'high_voltage': {'connector': '1.15', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 86,
-          'position': {'x': -30.71644127599237, 'y': 8.230445634260168},
-          'serial_number': 205.0,
-          'signal': {'connector': '1.15', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 7, 'crate': 0, 'module': 1244, 'slot': 10},
-          'high_voltage': {'connector': '3.12', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 87,
-          'position': {'x': -27.539607840345145, 'y': 15.900000000000006},
-          'serial_number': 543.0,
-          'signal': {'connector': '3.12', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 0, 'module': 1246, 'slot': 12},
-          'high_voltage': {'connector': '3.13', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 88,
-          'position': {'x': -22.48599564173221, 'y': 22.485995641732217},
-          'serial_number': 828.0,
-          'signal': {'connector': '3.13', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 1, 'crate': 0, 'module': 876, 'slot': 11},
-          'high_voltage': {'connector': '3.14', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 89,
-          'position': {'x': -15.899999999999997, 'y': 27.539607840345152},
-          'serial_number': 151.0,
-          'signal': {'connector': '3.14', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 6, 'crate': 0, 'module': 1243, 'slot': 13},
-          'high_voltage': {'connector': '3.19', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 90,
-          'position': {'x': -6.172834225695112, 'y': 23.037330956994282},
-          'serial_number': 207.0,
-          'signal': {'connector': '3.19', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 7, 'crate': 0, 'module': 876, 'slot': 11},
-          'high_voltage': {'connector': '3.20', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 91,
-          'position': {'x': 2.0786644645316468, 'y': 23.75924354948813},
-          'serial_number': 765.0,
-          'signal': {'connector': '3.20', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 2, 'crate': 0, 'module': 154, 'slot': 7},
-          'high_voltage': {'connector': '5.12', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 92,
-          'position': {'x': 10.079445542515693, 'y': 21.615440720824097},
-          'serial_number': 793.0,
-          'signal': {'connector': '5.12', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 0, 'crate': 1, 'module': 1257, 'slot': 14},
-          'high_voltage': {'connector': '0.16', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 93,
-          'position': {'x': 16.864496731299177, 'y': 16.864496731299145},
-          'serial_number': 656.0,
-          'signal': {'connector': '0.16', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 0, 'crate': 1, 'module': 1229, 'slot': 15},
-          'high_voltage': {'connector': '0.17', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 94,
-          'position': {'x': 21.61544072082411, 'y': 10.079445542515671},
-          'serial_number': 669.0,
-          'signal': {'connector': '0.17', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 2, 'crate': 1, 'module': 1229, 'slot': 15},
-          'high_voltage': {'connector': '0.18', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 95,
-          'position': {'x': 23.759243549488133, 'y': 2.078664464531644},
-          'serial_number': 827.0,
-          'signal': {'connector': '0.18', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 2, 'crate': 1, 'module': 1258, 'slot': 16},
-          'high_voltage': {'connector': '0.19', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 96,
-          'position': {'x': 23.037330956994275, 'y': -6.172834225695135},
-          'serial_number': 850.0,
-          'signal': {'connector': '0.19', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 0, 'module': 117, 'slot': 17},
-          'high_voltage': {'connector': '2.17', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 97,
-          'position': {'x': 19.536776256292445, 'y': -13.679798006972462},
-          'serial_number': 923.0,
-          'signal': {'connector': '2.17', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 3, 'crate': 0, 'module': 117, 'slot': 17},
-          'high_voltage': {'connector': '2.18', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 98,
-          'position': {'x': 13.679798006972446, 'y': -19.536776256292455},
-          'serial_number': 254.0,
-          'signal': {'connector': '2.18', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 0, 'module': 1234, 'slot': 16},
-          'high_voltage': {'connector': '2.19', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 99,
-          'position': {'x': 6.172834225695115, 'y': -23.037330956994282},
-          'serial_number': 558.0,
-          'signal': {'connector': '2.19', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 0, 'crate': 0, 'module': 1233, 'slot': 14},
-          'high_voltage': {'connector': '2.20', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 100,
-          'position': {'x': -2.0786644645316548, 'y': -23.75924354948813},
-          'serial_number': 219.0,
-          'signal': {'connector': '2.20', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 4, 'crate': 0, 'module': 1242, 'slot': 8},
-          'high_voltage': {'connector': '4.12', 'feedthrough': 1, 'return': 4},
-          'pmt_position': 101,
-          'position': {'x': -10.079445542515689, 'y': -21.615440720824097},
-          'serial_number': 152.0,
-          'signal': {'connector': '4.12', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 0, 'crate': 1, 'module': 1254, 'slot': 12},
-          'high_voltage': {'connector': '1.16', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 102,
-          'position': {'x': -16.864496731299162, 'y': -16.864496731299152},
-          'serial_number': 687.0,
-          'signal': {'connector': '1.16', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 3, 'crate': 1, 'module': 1227, 'slot': 13},
-          'high_voltage': {'connector': '1.17', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 103,
-          'position': {'x': -21.615440720824104, 'y': -10.079445542515678},
-          'serial_number': 925.0,
-          'signal': {'connector': '1.17', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 3, 'crate': 1, 'module': 1254, 'slot': 12},
-          'high_voltage': {'connector': '1.18', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 104,
-          'position': {'x': -23.759243549488133, 'y': -2.078664464531643},
-          'serial_number': 670.0,
-          'signal': {'connector': '1.18', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 3, 'crate': 1, 'module': 1219, 'slot': 11},
-          'high_voltage': {'connector': '1.19', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 105,
-          'position': {'x': -23.03733095699428, 'y': 6.172834225695126},
-          'serial_number': 718.0,
-          'signal': {'connector': '1.19', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 2, 'crate': 0, 'module': 1244, 'slot': 10},
-          'high_voltage': {'connector': '3.17', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 106,
-          'position': {'x': -19.536776256292452, 'y': 13.679798006972451},
-          'serial_number': 873.0,
-          'signal': {'connector': '3.17', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 4, 'crate': 0, 'module': 876, 'slot': 11},
-          'high_voltage': {'connector': '3.18', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 107,
-          'position': {'x': -13.679798006972447, 'y': 19.536776256292455},
-          'serial_number': 924.0,
-          'signal': {'connector': '3.18', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 0, 'crate': 0, 'module': 156, 'slot': 9},
-          'high_voltage': {'connector': '3.22', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 108,
-          'position': {'x': -4.115222817130075, 'y': 15.358220637996189},
-          'serial_number': 903.0,
-          'signal': {'connector': '3.22', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 3, 'crate': 0, 'module': 154, 'slot': 7},
-          'high_voltage': {'connector': '5.13', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 109,
-          'position': {'x': 4.115222817130091, 'y': 15.358220637996183},
-          'serial_number': 220.0,
-          'signal': {'connector': '5.13', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 3, 'crate': 1, 'module': 1258, 'slot': 16},
-          'high_voltage': {'connector': '0.20', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 110,
-          'position': {'x': 11.242997820866107, 'y': 11.242997820866107},
-          'serial_number': 229.0,
-          'signal': {'connector': '0.20', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 3, 'crate': 1, 'module': 1229, 'slot': 15},
-          'high_voltage': {'connector': '0.21', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 111,
-          'position': {'x': 15.358220637996187, 'y': 4.115222817130076},
-          'serial_number': 761.0,
-          'signal': {'connector': '0.21', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 4, 'crate': 1, 'module': 1258, 'slot': 16},
-          'high_voltage': {'connector': '0.22', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 112,
-          'position': {'x': 15.358220637996183, 'y': -4.115222817130091},
-          'serial_number': 816.0,
-          'signal': {'connector': '0.22', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 6, 'crate': 0, 'module': 117, 'slot': 17},
-          'high_voltage': {'connector': '2.21', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 113,
-          'position': {'x': 11.242997820866101, 'y': -11.242997820866112},
-          'serial_number': 912.0,
-          'signal': {'connector': '2.21', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 3, 'crate': 0, 'module': 1234, 'slot': 16},
-          'high_voltage': {'connector': '2.22', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 114,
-          'position': {'x': 4.115222817130077, 'y': -15.358220637996187},
-          'serial_number': 920.0,
-          'signal': {'connector': '2.22', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 6, 'crate': 0, 'module': 156, 'slot': 9},
-          'high_voltage': {'connector': '4.13', 'feedthrough': 1, 'return': 4},
-          'pmt_position': 115,
-          'position': {'x': -4.115222817130081, 'y': -15.358220637996187},
-          'serial_number': 146.0,
-          'signal': {'connector': '4.13', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 4, 'crate': 1, 'module': 1227, 'slot': 13},
-          'high_voltage': {'connector': '1.20', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 116,
-          'position': {'x': -11.242997820866108, 'y': -11.242997820866101},
-          'serial_number': 154.0,
-          'signal': {'connector': '1.20', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 6, 'crate': 1, 'module': 1219, 'slot': 11},
-          'high_voltage': {'connector': '1.21', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 117,
-          'position': {'x': -15.358220637996187, 'y': -4.1152228171300775},
-          'serial_number': 556.0,
-          'signal': {'connector': '1.21', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 7, 'crate': 1, 'module': 1219, 'slot': 11},
-          'high_voltage': {'connector': '1.22', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 118,
-          'position': {'x': -15.358220637996185, 'y': 4.115222817130084},
-          'serial_number': 541.0,
-          'signal': {'connector': '1.22', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 6, 'crate': 0, 'module': 876, 'slot': 11},
-          'high_voltage': {'connector': '3.21', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 119,
-          'position': {'x': -11.242997820866105, 'y': 11.242997820866108},
-          'serial_number': 616.0,
-          'signal': {'connector': '3.21', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 1, 'crate': 0, 'module': 156, 'slot': 9},
-          'high_voltage': {'connector': '3.23', 'feedthrough': 0, 'return': 3},
-          'pmt_position': 120,
-          'position': {'x': -2.0576114085650374, 'y': 7.679110318998094},
-          'serial_number': 818.0,
-          'signal': {'connector': '3.23', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 3, 'crate': 0, 'module': 153, 'slot': 5},
-          'high_voltage': {'connector': '5.14', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 121,
-          'position': {'x': 5.621498910433053, 'y': 5.621498910433053},
-          'serial_number': 872.0,
-          'signal': {'connector': '5.14', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 1, 'module': 1258, 'slot': 16},
-          'high_voltage': {'connector': '0.23', 'feedthrough': 0, 'return': 0},
-          'pmt_position': 122,
-          'position': {'x': 7.679110318998092, 'y': -2.0576114085650454},
-          'serial_number': 210.0,
-          'signal': {'connector': '0.23', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 7, 'crate': 0, 'module': 117, 'slot': 17},
-          'high_voltage': {'connector': '2.23', 'feedthrough': 0, 'return': 2},
-          'pmt_position': 123,
-          'position': {'x': 2.0576114085650383, 'y': -7.679110318998093},
-          'serial_number': 227.0,
-          'signal': {'connector': '2.23', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 5, 'crate': 0, 'module': 1242, 'slot': 8},
-          'high_voltage': {'connector': '4.14', 'feedthrough': 1, 'return': 4},
-          'pmt_position': 124,
-          'position': {'x': -5.621498910433054, 'y': -5.621498910433051},
-          'serial_number': 202.0,
-          'signal': {'connector': '4.14', 'feedthrough': 1}},
-         {'array': 'top',
-          'digitizer': {'channel': 7, 'crate': 1, 'module': 1254, 'slot': 12},
-          'high_voltage': {'connector': '1.23', 'feedthrough': 0, 'return': 1},
-          'pmt_position': 125,
-          'position': {'x': -7.6791103189980925, 'y': 2.057611408565042},
-          'serial_number': 231.0,
-          'signal': {'connector': '1.23', 'feedthrough': 0}},
-         {'array': 'top',
-          'digitizer': {'channel': 6, 'crate': 0, 'module': 1242, 'slot': 8},
-          'high_voltage': {'connector': '4.15', 'feedthrough': 1, 'return': 4},
-          'pmt_position': 126,
-          'position': {'x': 0.0, 'y': 0.0},
-          'serial_number': 752.0,
-          'signal': {'connector': '4.15', 'feedthrough': 1}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 2, 'crate': 1, 'module': 1161, 'slot': 3},
-          'high_voltage': {'connector': '6.0', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 127,
-          'position': {'x': -30.689924073888996, 'y': 32.28201605133931},
-          'serial_number': 806.0,
-          'signal': {'connector': '6.0', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 1, 'crate': 1, 'module': 1187, 'slot': 7},
-          'high_voltage': {'connector': '6.01', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 128,
-          'position': {'x': -23.2988878137987, 'y': 35.34348351026003},
-          'serial_number': 175.0,
-          'signal': {'connector': '6.01', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 2, 'crate': 1, 'module': 1187, 'slot': 7},
-          'high_voltage': {'connector': '6.02', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 129,
-          'position': {'x': -15.907851553708406, 'y': 38.404950969180746},
-          'serial_number': 163.0,
-          'signal': {'connector': '6.02', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 3, 'crate': 1, 'module': 1249, 'slot': 4},
-          'high_voltage': {'connector': '6.03', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 130,
-          'position': {'x': -8.516815293618112, 'y': 41.46641842810146},
-          'serial_number': 742.0,
-          'signal': {'connector': '6.03', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 3, 'crate': 1, 'module': 1187, 'slot': 7},
-          'high_voltage': {'connector': '6.04', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 131,
-          'position': {'x': -1.1257790335278184, 'y': 44.52788588702218},
-          'serial_number': 751.0,
-          'signal': {'connector': '6.04', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 0, 'crate': 1, 'module': 1092, 'slot': 1},
-          'high_voltage': {'connector': '8.0', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 132,
-          'position': {'x': -39.1251698717397, 'y': 21.2889897014281},
-          'serial_number': 854.0,
-          'signal': {'connector': '8.0', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 0, 'crate': 1, 'module': 1247, 'slot': 2},
-          'high_voltage': {'connector': '8.01', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 133,
-          'position': {'x': -31.734133611649405, 'y': 24.35045716034882},
-          'serial_number': 124.0,
-          'signal': {'connector': '8.01', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 3, 'crate': 1, 'module': 1212, 'slot': 5},
-          'high_voltage': {'connector': '6.05', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 134,
-          'position': {'x': -24.34309735155911, 'y': 27.41192461926954},
-          'serial_number': 123.0,
-          'signal': {'connector': '6.05', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 4, 'crate': 1, 'module': 1249, 'slot': 4},
-          'high_voltage': {'connector': '6.06', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 135,
-          'position': {'x': -16.952061091468817, 'y': 30.47339207819026},
-          'serial_number': 668.0,
-          'signal': {'connector': '6.06', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 4, 'crate': 1, 'module': 1212, 'slot': 5},
-          'high_voltage': {'connector': '6.07', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 136,
-          'position': {'x': -9.561024831378525, 'y': 33.534859537110975},
-          'serial_number': 754.0,
-          'signal': {'connector': '6.07', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 0, 'crate': 1, 'module': 1249, 'slot': 4},
-          'high_voltage': {'connector': '6.08', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 137,
-          'position': {'x': -2.169988571288231, 'y': 36.59632699603169},
-          'serial_number': 904.0,
-          'signal': {'connector': '6.08', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 0, 'crate': 1, 'module': 1212, 'slot': 5},
-          'high_voltage': {'connector': '6.09', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 138,
-          'position': {'x': 5.221047688802065, 'y': 39.65779445495241},
-          'serial_number': 855.0,
-          'signal': {'connector': '6.09', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 1, 'crate': 1, 'module': 1161, 'slot': 3},
-          'high_voltage': {'connector': '6.10', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 139,
-          'position': {'x': 12.612083948892357, 'y': 42.71926191387313},
-          'serial_number': 760.0,
-          'signal': {'connector': '6.10', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 1, 'crate': 1, 'module': 1247, 'slot': 2},
-          'high_voltage': {'connector': '8.02', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 140,
-          'position': {'x': -40.16937940950011, 'y': 13.357430810437622},
-          'serial_number': 809.0,
-          'signal': {'connector': '8.02', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 3, 'crate': 1, 'module': 1247, 'slot': 2},
-          'high_voltage': {'connector': '8.03', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 141,
-          'position': {'x': -32.77834314940982, 'y': 16.41889826935834},
-          'serial_number': 170.0,
-          'signal': {'connector': '8.03', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 5, 'crate': 1, 'module': 1092, 'slot': 1},
-          'high_voltage': {'connector': '8.04', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 142,
-          'position': {'x': -25.387306889319525, 'y': 19.480365728279057},
-          'serial_number': 785.0,
-          'signal': {'connector': '8.04', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 0, 'crate': 1, 'module': 1250, 'slot': 6},
-          'high_voltage': {'connector': '6.11', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 143,
-          'position': {'x': -17.99627062922923, 'y': 22.541833187199778},
-          'serial_number': 215.0,
-          'signal': {'connector': '6.11', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 1, 'crate': 1, 'module': 1250, 'slot': 6},
-          'high_voltage': {'connector': '6.12', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 144,
-          'position': {'x': -10.605234369138937, 'y': 25.603300646120495},
-          'serial_number': 122.0,
-          'signal': {'connector': '6.12', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 1, 'crate': 1, 'module': 1212, 'slot': 5},
-          'high_voltage': {'connector': '6.13', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 145,
-          'position': {'x': -3.2141981090486436, 'y': 28.66476810504121},
-          'serial_number': 125.0,
-          'signal': {'connector': '6.13', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 2, 'crate': 1, 'module': 1249, 'slot': 4},
-          'high_voltage': {'connector': '6.14', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 146,
-          'position': {'x': 4.17683815104165, 'y': 31.726235563961932},
-          'serial_number': 786.0,
-          'signal': {'connector': '6.14', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 2, 'crate': 1, 'module': 1212, 'slot': 5},
-          'high_voltage': {'connector': '6.15', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 147,
-          'position': {'x': 11.567874411131942, 'y': 34.78770302288265},
-          'serial_number': 501.0,
-          'signal': {'connector': '6.15', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 1, 'crate': 0, 'module': 1233, 'slot': 14},
-          'high_voltage': {'connector': '5.21', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 148,
-          'position': {'x': 18.958910671222238, 'y': 37.84917048180337},
-          'serial_number': 767.0,
-          'signal': {'connector': '11.15', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 6, 'crate': 1, 'module': 1092, 'slot': 1},
-          'high_voltage': {'connector': '8.05', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 149,
-          'position': {'x': -41.213588947260526, 'y': 5.425871919447141},
-          'serial_number': 926.0,
-          'signal': {'connector': '8.05', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 6, 'crate': 1, 'module': 1247, 'slot': 2},
-          'high_voltage': {'connector': '8.06', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 150,
-          'position': {'x': -33.82255268717023, 'y': 8.487339378367858},
-          'serial_number': 204.0,
-          'signal': {'connector': '8.06', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 7, 'crate': 1, 'module': 1247, 'slot': 2},
-          'high_voltage': {'connector': '8.07', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 151,
-          'position': {'x': -26.431516427079938, 'y': 11.548806837288577},
-          'serial_number': 777.0,
-          'signal': {'connector': '8.07', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 1, 'crate': 1, 'module': 1092, 'slot': 1},
-          'high_voltage': {'connector': '8.08', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 152,
-          'position': {'x': -19.040480166989642, 'y': 14.610274296209296},
-          'serial_number': 743.0,
-          'signal': {'connector': '8.08', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 0, 'crate': 1, 'module': 1161, 'slot': 3},
-          'high_voltage': {'connector': '6.16', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 153,
-          'position': {'x': -11.64944390689935, 'y': 17.671741755130014},
-          'serial_number': 787.0,
-          'signal': {'connector': '6.16', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 0, 'crate': 1, 'module': 1187, 'slot': 7},
-          'high_voltage': {'connector': '6.17', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 154,
-          'position': {'x': -4.258407646809056, 'y': 20.73320921405073},
-          'serial_number': 134.0,
-          'signal': {'connector': '6.17', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 1, 'crate': 1, 'module': 1249, 'slot': 4},
-          'high_voltage': {'connector': '6.18', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 155,
-          'position': {'x': 3.132628613281237, 'y': 23.79467667297145},
-          'serial_number': 135.0,
-          'signal': {'connector': '6.18', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 2, 'crate': 1, 'module': 1250, 'slot': 6},
-          'high_voltage': {'connector': '6.19', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 156,
-          'position': {'x': 10.523664873371533, 'y': 26.85614413189217},
-          'serial_number': 121.0,
-          'signal': {'connector': '6.19', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 0, 'crate': 1, 'module': 1251, 'slot': 8},
-          'high_voltage': {'connector': '7.0', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 157,
-          'position': {'x': 17.914701133461826, 'y': 29.91761159081289},
-          'serial_number': 679.0,
-          'signal': {'connector': '7.0', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 1, 'crate': 1, 'module': 1216, 'slot': 9},
-          'high_voltage': {'connector': '7.01', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 158,
-          'position': {'x': 25.305737393552118, 'y': 32.979079049733606},
-          'serial_number': 768.0,
-          'signal': {'connector': '7.01', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 3, 'crate': 1, 'module': 1092, 'slot': 1},
-          'high_voltage': {'connector': '8.09', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 159,
-          'position': {'x': -42.25779848502094, 'y': -2.5056869715433443},
-          'serial_number': 916.0,
-          'signal': {'connector': '8.09', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 2, 'crate': 1, 'module': 1247, 'slot': 2},
-          'high_voltage': {'connector': '8.10', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 160,
-          'position': {'x': -34.866762224930646, 'y': 0.5557804873773744},
-          'serial_number': 203.0,
-          'signal': {'connector': '8.10', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 2, 'crate': 1, 'module': 1092, 'slot': 1},
-          'high_voltage': {'connector': '8.11', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 161,
-          'position': {'x': -27.47572596484035, 'y': 3.617247946298093},
-          'serial_number': 196.0,
-          'signal': {'connector': '8.11', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 5, 'crate': 1, 'module': 1247, 'slot': 2},
-          'high_voltage': {'connector': '8.12', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 162,
-          'position': {'x': -20.084689704750055, 'y': 6.678715405218811},
-          'serial_number': 183.0,
-          'signal': {'connector': '8.12', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 4, 'crate': 1, 'module': 1247, 'slot': 2},
-          'high_voltage': {'connector': '8.13', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 163,
-          'position': {'x': -12.693653444659763, 'y': 9.740182864139529},
-          'serial_number': 113.0,
-          'signal': {'connector': '8.13', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 3, 'crate': 1, 'module': 1161, 'slot': 3},
-          'high_voltage': {'connector': '6.20', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 164,
-          'position': {'x': -5.302617184569469, 'y': 12.801650323060247},
-          'serial_number': 127.0,
-          'signal': {'connector': '6.20', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 4, 'crate': 1, 'module': 1161, 'slot': 3},
-          'high_voltage': {'connector': '6.21', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 165,
-          'position': {'x': 2.088419075520825, 'y': 15.863117781980966},
-          'serial_number': 120.0,
-          'signal': {'connector': '6.21', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 3, 'crate': 1, 'module': 1250, 'slot': 6},
-          'high_voltage': {'connector': '6.22', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 166,
-          'position': {'x': 9.479455335611119, 'y': 18.924585240901685},
-          'serial_number': 218.0,
-          'signal': {'connector': '6.22', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 2, 'crate': 1, 'module': 1216, 'slot': 9},
-          'high_voltage': {'connector': '7.02', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 167,
-          'position': {'x': 16.87049159570141, 'y': 21.9860526998224},
-          'serial_number': 148.0,
-          'signal': {'connector': '7.02', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 3, 'crate': 1, 'module': 1251, 'slot': 8},
-          'high_voltage': {'connector': '7.03', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 168,
-          'position': {'x': 24.261527855791705, 'y': 25.04752015874312},
-          'serial_number': 206.0,
-          'signal': {'connector': '7.03', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 2, 'crate': 1, 'module': 1251, 'slot': 8},
-          'high_voltage': {'connector': '7.04', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 169,
-          'position': {'x': 31.652564115882, 'y': 28.10898761766384},
-          'serial_number': 772.0,
-          'signal': {'connector': '7.04', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 7, 'crate': 1, 'module': 1092, 'slot': 1},
-          'high_voltage': {'connector': '8.14', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 170,
-          'position': {'x': -43.30200802278135, 'y': -10.437245862533826},
-          'serial_number': 901.0,
-          'signal': {'connector': '8.14', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 4, 'crate': 1, 'module': 1092, 'slot': 1},
-          'high_voltage': {'connector': '8.15', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 171,
-          'position': {'x': -35.910971762691055, 'y': -7.375778403613108},
-          'serial_number': 173.0,
-          'signal': {'connector': '8.15', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 0, 'crate': 0, 'module': 1234, 'slot': 16},
-          'high_voltage': {'connector': '8.16', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 172,
-          'position': {'x': -28.519935502600763, 'y': -4.314310944692391},
-          'serial_number': 801.0,
-          'signal': {'connector': '8.16', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 1, 'crate': 0, 'module': 117, 'slot': 17},
-          'high_voltage': {'connector': '8.17', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 173,
-          'position': {'x': -21.12889924251047, 'y': -1.2528434857716721},
-          'serial_number': 166.0,
-          'signal': {'connector': '8.17', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 0, 'crate': 0, 'module': 117, 'slot': 17},
-          'high_voltage': {'connector': '8.18', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 174,
-          'position': {'x': -13.737862982420175, 'y': 1.8086239731490465},
-          'serial_number': 109.0,
-          'signal': {'connector': '8.18', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 1, 'crate': 0, 'module': 1234, 'slot': 16},
-          'high_voltage': {'connector': '8.19', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 175,
-          'position': {'x': -6.346826722329881, 'y': 4.870091432069764},
-          'serial_number': 748.0,
-          'signal': {'connector': '8.19', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 4, 'crate': 1, 'module': 1250, 'slot': 6},
-          'high_voltage': {'connector': '6.23', 'feedthrough': 1, 'return': 6},
-          'pmt_position': 176,
-          'position': {'x': 1.0442095377604126, 'y': 7.931558890990483},
-          'serial_number': 106.0,
-          'signal': {'connector': '6.23', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 5, 'crate': 1, 'module': 1253, 'slot': 10},
-          'high_voltage': {'connector': '7.05', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 177,
-          'position': {'x': 8.435245797850705, 'y': 10.9930263499112},
-          'serial_number': 117.0,
-          'signal': {'connector': '7.05', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 7, 'crate': 1, 'module': 1253, 'slot': 10},
-          'high_voltage': {'connector': '7.06', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 178,
-          'position': {'x': 15.826282057941, 'y': 14.05449380883192},
-          'serial_number': 769.0,
-          'signal': {'connector': '7.06', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 7, 'crate': 1, 'module': 1216, 'slot': 9},
-          'high_voltage': {'connector': '7.07', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 179,
-          'position': {'x': 23.217318318031293, 'y': 17.11596126775264},
-          'serial_number': 167.0,
-          'signal': {'connector': '7.07', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 2, 'crate': 1, 'module': 1253, 'slot': 10},
-          'high_voltage': {'connector': '7.08', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 180,
-          'position': {'x': 30.608354578121585, 'y': 20.177428726673355},
-          'serial_number': 844.0,
-          'signal': {'connector': '7.08', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 3, 'crate': 1, 'module': 1253, 'slot': 10},
-          'high_voltage': {'connector': '7.09', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 181,
-          'position': {'x': 37.99939083821188, 'y': 23.238896185594072},
-          'serial_number': 773.0,
-          'signal': {'connector': '7.09', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 2, 'crate': 0, 'module': 117, 'slot': 17},
-          'high_voltage': {'connector': '8.20', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 182,
-          'position': {'x': -36.95518130045147, 'y': -15.307337294603592},
-          'serial_number': 914.0,
-          'signal': {'connector': '8.20', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 4, 'crate': 0, 'module': 1234, 'slot': 16},
-          'high_voltage': {'connector': '8.21', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 183,
-          'position': {'x': -29.564145040361176, 'y': -12.245869835682873},
-          'serial_number': 591.0,
-          'signal': {'connector': '8.21', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 1, 'crate': 0, 'module': 110, 'slot': 15},
-          'high_voltage': {'connector': '10.0', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 184,
-          'position': {'x': -22.17310878027088, 'y': -9.184402376762154},
-          'serial_number': 158.0,
-          'signal': {'connector': '10.0', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 0, 'crate': 0, 'module': 1243, 'slot': 13},
-          'high_voltage': {'connector': '10.01', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 185,
-          'position': {'x': -14.782072520180588, 'y': -6.1229349178414365},
-          'serial_number': 803.0,
-          'signal': {'connector': '10.01', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 2, 'crate': 0, 'module': 1233, 'slot': 14},
-          'high_voltage': {'connector': '10.02', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 186,
-          'position': {'x': -7.391036260090294, 'y': -3.0614674589207183},
-          'serial_number': 802.0,
-          'signal': {'connector': '10.02', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 4, 'crate': 0, 'module': 117, 'slot': 17},
-          'high_voltage': {'connector': '8.22', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 187,
-          'position': {'x': 0.0, 'y': 0.0},
-          'serial_number': 799.0,
-          'signal': {'connector': '8.22', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 3, 'crate': 1, 'module': 1216, 'slot': 9},
-          'high_voltage': {'connector': '7.10', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 188,
-          'position': {'x': 7.391036260090294, 'y': 3.0614674589207183},
-          'serial_number': 178.0,
-          'signal': {'connector': '7.10', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 4, 'crate': 1, 'module': 1253, 'slot': 10},
-          'high_voltage': {'connector': '7.11', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 189,
-          'position': {'x': 14.782072520180588, 'y': 6.1229349178414365},
-          'serial_number': 129.0,
-          'signal': {'connector': '7.11', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 5, 'crate': 1, 'module': 1216, 'slot': 9},
-          'high_voltage': {'connector': '7.12', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 190,
-          'position': {'x': 22.17310878027088, 'y': 9.184402376762154},
-          'serial_number': 103.0,
-          'signal': {'connector': '7.12', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 6, 'crate': 1, 'module': 1253, 'slot': 10},
-          'high_voltage': {'connector': '7.13', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 191,
-          'position': {'x': 29.564145040361176, 'y': 12.245869835682873},
-          'serial_number': 172.0,
-          'signal': {'connector': '7.13', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 6, 'crate': 1, 'module': 1251, 'slot': 8},
-          'high_voltage': {'connector': '7.14', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 192,
-          'position': {'x': 36.95518130045147, 'y': 15.307337294603592},
-          'serial_number': 846.0,
-          'signal': {'connector': '7.14', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 7, 'crate': 0, 'module': 1234, 'slot': 16},
-          'high_voltage': {'connector': '8.23', 'feedthrough': 2, 'return': 8},
-          'pmt_position': 193,
-          'position': {'x': -37.99939083821188, 'y': -23.238896185594072},
-          'serial_number': 899.0,
-          'signal': {'connector': '8.23', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 3, 'crate': 0, 'module': 1243, 'slot': 13},
-          'high_voltage': {'connector': '10.03', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 194,
-          'position': {'x': -30.608354578121585, 'y': -20.177428726673355},
-          'serial_number': 849.0,
-          'signal': {'connector': '10.03', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 3, 'crate': 0, 'module': 1233, 'slot': 14},
-          'high_voltage': {'connector': '10.04', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 195,
-          'position': {'x': -23.217318318031293, 'y': -17.11596126775264},
-          'serial_number': 179.0,
-          'signal': {'connector': '10.04', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 3, 'crate': 0, 'module': 1246, 'slot': 12},
-          'high_voltage': {'connector': '10.05', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 196,
-          'position': {'x': -15.826282057941, 'y': -14.05449380883192},
-          'serial_number': 111.0,
-          'signal': {'connector': '10.05', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 4, 'crate': 0, 'module': 1233, 'slot': 14},
-          'high_voltage': {'connector': '10.06', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 197,
-          'position': {'x': -8.435245797850705, 'y': -10.9930263499112},
-          'serial_number': 130.0,
-          'signal': {'connector': '10.06', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 4, 'crate': 0, 'module': 1246, 'slot': 12},
-          'high_voltage': {'connector': '10.07', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 198,
-          'position': {'x': -1.0442095377604126, 'y': -7.931558890990483},
-          'serial_number': 746.0,
-          'signal': {'connector': '10.07', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 0, 'crate': 0, 'module': 1237, 'slot': 20},
-          'high_voltage': {'connector': '9.0', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 199,
-          'position': {'x': 6.346826722329881, 'y': -4.870091432069764},
-          'serial_number': 805.0,
-          'signal': {'connector': '9.0', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 0, 'crate': 0, 'module': 127, 'slot': 19},
-          'high_voltage': {'connector': '9.01', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 200,
-          'position': {'x': 13.737862982420175, 'y': -1.8086239731490465},
-          'serial_number': 110.0,
-          'signal': {'connector': '9.01', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 7, 'crate': 1, 'module': 1251, 'slot': 8},
-          'high_voltage': {'connector': '7.15', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 201,
-          'position': {'x': 21.12889924251047, 'y': 1.2528434857716721},
-          'serial_number': 116.0,
-          'signal': {'connector': '7.15', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 0, 'crate': 1, 'module': 1216, 'slot': 9},
-          'high_voltage': {'connector': '7.16', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 202,
-          'position': {'x': 28.519935502600763, 'y': 4.314310944692391},
-          'serial_number': 248.0,
-          'signal': {'connector': '7.16', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 1, 'crate': 1, 'module': 1253, 'slot': 10},
-          'high_voltage': {'connector': '7.17', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 203,
-          'position': {'x': 35.910971762691055, 'y': 7.375778403613108},
-          'serial_number': 588.0,
-          'signal': {'connector': '7.17', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 0, 'crate': 1, 'module': 1253, 'slot': 10},
-          'high_voltage': {'connector': '7.18', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 204,
-          'position': {'x': 43.30200802278135, 'y': 10.437245862533826},
-          'serial_number': 792.0,
-          'signal': {'connector': '7.18', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 5, 'crate': 0, 'module': 110, 'slot': 15},
-          'high_voltage': {'connector': '10.08', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 205,
-          'position': {'x': -31.652564115882, 'y': -28.10898761766384},
-          'serial_number': 879.0,
-          'signal': {'connector': '10.08', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 7, 'crate': 0, 'module': 1233, 'slot': 14},
-          'high_voltage': {'connector': '10.09', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 206,
-          'position': {'x': -24.261527855791705, 'y': -25.04752015874312},
-          'serial_number': 707.0,
-          'signal': {'connector': '10.09', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 5, 'crate': 0, 'module': 1233, 'slot': 14},
-          'high_voltage': {'connector': '10.10', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 207,
-          'position': {'x': -16.87049159570141, 'y': -21.9860526998224},
-          'serial_number': 847.0,
-          'signal': {'connector': '10.10', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 6, 'crate': 0, 'module': 1233, 'slot': 14},
-          'high_voltage': {'connector': '10.11', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 208,
-          'position': {'x': -9.479455335611119, 'y': -18.924585240901685},
-          'serial_number': 107.0,
-          'signal': {'connector': '10.11', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 7, 'crate': 0, 'module': 110, 'slot': 15},
-          'high_voltage': {'connector': '10.12', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 209,
-          'position': {'x': -2.088419075520825, 'y': -15.863117781980966},
-          'serial_number': 112.0,
-          'signal': {'connector': '10.12', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 0, 'crate': 0, 'module': 1236, 'slot': 18},
-          'high_voltage': {'connector': '9.02', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 210,
-          'position': {'x': 5.302617184569469, 'y': -12.801650323060247},
-          'serial_number': 840.0,
-          'signal': {'connector': '9.02', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 2, 'crate': 0, 'module': 1237, 'slot': 20},
-          'high_voltage': {'connector': '9.03', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 211,
-          'position': {'x': 12.693653444659763, 'y': -9.740182864139529},
-          'serial_number': 807.0,
-          'signal': {'connector': '9.03', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 2, 'crate': 0, 'module': 1236, 'slot': 18},
-          'high_voltage': {'connector': '9.04', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 212,
-          'position': {'x': 20.084689704750055, 'y': -6.678715405218811},
-          'serial_number': 774.0,
-          'signal': {'connector': '9.04', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 1, 'crate': 1, 'module': 1251, 'slot': 8},
-          'high_voltage': {'connector': '7.19', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 213,
-          'position': {'x': 27.47572596484035, 'y': -3.617247946298093},
-          'serial_number': 169.0,
-          'signal': {'connector': '7.19', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 4, 'crate': 1, 'module': 1251, 'slot': 8},
-          'high_voltage': {'connector': '7.20', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 214,
-          'position': {'x': 34.866762224930646, 'y': -0.5557804873773744},
-          'serial_number': 750.0,
-          'signal': {'connector': '7.20', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 4, 'crate': 1, 'module': 1216, 'slot': 9},
-          'high_voltage': {'connector': '7.21', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 215,
-          'position': {'x': 42.25779848502094, 'y': 2.5056869715433443},
-          'serial_number': 797.0,
-          'signal': {'connector': '7.21', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 0, 'crate': 0, 'module': 1246, 'slot': 12},
-          'high_voltage': {'connector': '10.13', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 216,
-          'position': {'x': -25.305737393552118, 'y': -32.979079049733606},
-          'serial_number': 871.0,
-          'signal': {'connector': '10.13', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 1, 'crate': 0, 'module': 1246, 'slot': 12},
-          'high_voltage': {'connector': '10.14', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 217,
-          'position': {'x': -17.914701133461826, 'y': -29.91761159081289},
-          'serial_number': 456.0,
-          'signal': {'connector': '10.14', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 1, 'crate': 0, 'module': 1243, 'slot': 13},
-          'high_voltage': {'connector': '10.15', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 218,
-          'position': {'x': -10.523664873371533, 'y': -26.85614413189217},
-          'serial_number': 776.0,
-          'signal': {'connector': '10.15', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 2, 'crate': 0, 'module': 110, 'slot': 15},
-          'high_voltage': {'connector': '10.16', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 219,
-          'position': {'x': -3.132628613281237, 'y': -23.79467667297145},
-          'serial_number': 864.0,
-          'signal': {'connector': '10.16', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 3, 'crate': 0, 'module': 1237, 'slot': 20},
-          'high_voltage': {'connector': '9.05', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 220,
-          'position': {'x': 4.258407646809056, 'y': -20.73320921405073},
-          'serial_number': 136.0,
-          'signal': {'connector': '9.05', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 3, 'crate': 0, 'module': 1236, 'slot': 18},
-          'high_voltage': {'connector': '9.06', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 221,
-          'position': {'x': 11.64944390689935, 'y': -17.671741755130014},
-          'serial_number': 788.0,
-          'signal': {'connector': '9.06', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 4, 'crate': 0, 'module': 127, 'slot': 19},
-          'high_voltage': {'connector': '9.07', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 222,
-          'position': {'x': 19.040480166989642, 'y': -14.610274296209296},
-          'serial_number': 115.0,
-          'signal': {'connector': '9.07', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 5, 'crate': 0, 'module': 1237, 'slot': 20},
-          'high_voltage': {'connector': '9.08', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 223,
-          'position': {'x': 26.431516427079938, 'y': -11.548806837288577},
-          'serial_number': 800.0,
-          'signal': {'connector': '9.08', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 5, 'crate': 1, 'module': 1251, 'slot': 8},
-          'high_voltage': {'connector': '7.22', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 224,
-          'position': {'x': 33.82255268717023, 'y': -8.487339378367858},
-          'serial_number': 842.0,
-          'signal': {'connector': '7.22', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 6, 'crate': 1, 'module': 1216, 'slot': 9},
-          'high_voltage': {'connector': '7.23', 'feedthrough': 1, 'return': 7},
-          'pmt_position': 225,
-          'position': {'x': 41.213588947260526, 'y': -5.425871919447141},
-          'serial_number': 798.0,
-          'signal': {'connector': '7.23', 'feedthrough': 2}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 2, 'crate': 0, 'module': 1243, 'slot': 13},
-          'high_voltage': {'connector': '10.17', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 226,
-          'position': {'x': -18.958910671222238, 'y': -37.84917048180337},
-          'serial_number': 868.0,
-          'signal': {'connector': '10.17', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 3, 'crate': 0, 'module': 110, 'slot': 15},
-          'high_voltage': {'connector': '10.18', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 227,
-          'position': {'x': -11.567874411131942, 'y': -34.78770302288265},
-          'serial_number': 126.0,
-          'signal': {'connector': '10.18', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 2, 'crate': 0, 'module': 1246, 'slot': 12},
-          'high_voltage': {'connector': '10.19', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 228,
-          'position': {'x': -4.17683815104165, 'y': -31.726235563961932},
-          'serial_number': 174.0,
-          'signal': {'connector': '10.19', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 5, 'crate': 0, 'module': 1236, 'slot': 18},
-          'high_voltage': {'connector': '9.09', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 229,
-          'position': {'x': 3.2141981090486436, 'y': -28.66476810504121},
-          'serial_number': 592.0,
-          'signal': {'connector': '9.09', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 7, 'crate': 0, 'module': 1237, 'slot': 20},
-          'high_voltage': {'connector': '9.10', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 230,
-          'position': {'x': 10.605234369138937, 'y': -25.603300646120495},
-          'serial_number': 177.0,
-          'signal': {'connector': '9.10', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 6, 'crate': 0, 'module': 1236, 'slot': 18},
-          'high_voltage': {'connector': '9.11', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 231,
-          'position': {'x': 17.99627062922923, 'y': -22.541833187199778},
-          'serial_number': 105.0,
-          'signal': {'connector': '9.11', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 6, 'crate': 0, 'module': 1237, 'slot': 20},
-          'high_voltage': {'connector': '9.12', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 232,
-          'position': {'x': 25.387306889319525, 'y': -19.480365728279057},
-          'serial_number': 246.0,
-          'signal': {'connector': '9.12', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 6, 'crate': 0, 'module': 127, 'slot': 19},
-          'high_voltage': {'connector': '9.13', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 233,
-          'position': {'x': 32.77834314940982, 'y': -16.41889826935834},
-          'serial_number': 168.0,
-          'signal': {'connector': '9.13', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 7, 'crate': 0, 'module': 1236, 'slot': 18},
-          'high_voltage': {'connector': '9.14', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 234,
-          'position': {'x': 40.16937940950011, 'y': -13.357430810437622},
-          'serial_number': 810.0,
-          'signal': {'connector': '9.14', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 4, 'crate': 0, 'module': 110, 'slot': 15},
-          'high_voltage': {'connector': '10.20', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 235,
-          'position': {'x': -12.612083948892357, 'y': -42.71926191387313},
-          'serial_number': 853.0,
-          'signal': {'connector': '10.20', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 4, 'crate': 0, 'module': 1243, 'slot': 13},
-          'high_voltage': {'connector': '10.21', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 236,
-          'position': {'x': -5.221047688802065, 'y': -39.65779445495241},
-          'serial_number': 927.0,
-          'signal': {'connector': '10.21', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 5, 'crate': 0, 'module': 1243, 'slot': 13},
-          'high_voltage': {'connector': '10.22', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 237,
-          'position': {'x': 2.169988571288231, 'y': -36.59632699603169},
-          'serial_number': 224.0,
-          'signal': {'connector': '10.22', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 7, 'crate': 0, 'module': 127, 'slot': 19},
-          'high_voltage': {'connector': '9.15', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 238,
-          'position': {'x': 9.561024831378525, 'y': -33.534859537110975},
-          'serial_number': 589.0,
-          'signal': {'connector': '9.15', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 1, 'crate': 0, 'module': 1237, 'slot': 20},
-          'high_voltage': {'connector': '9.16', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 239,
-          'position': {'x': 16.952061091468817, 'y': -30.47339207819026},
-          'serial_number': 560.0,
-          'signal': {'connector': '9.16', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 1, 'crate': 0, 'module': 1236, 'slot': 18},
-          'high_voltage': {'connector': '9.17', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 240,
-          'position': {'x': 24.34309735155911, 'y': -27.41192461926954},
-          'serial_number': 217.0,
-          'signal': {'connector': '9.17', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 1, 'crate': 0, 'module': 127, 'slot': 19},
-          'high_voltage': {'connector': '9.18', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 241,
-          'position': {'x': 31.734133611649405, 'y': -24.35045716034882},
-          'serial_number': 212.0,
-          'signal': {'connector': '9.18', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 2, 'crate': 0, 'module': 127, 'slot': 19},
-          'high_voltage': {'connector': '9.19', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 242,
-          'position': {'x': 39.1251698717397, 'y': -21.2889897014281},
-          'serial_number': 822.0,
-          'signal': {'connector': '9.19', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 6, 'crate': 0, 'module': 110, 'slot': 15},
-          'high_voltage': {'connector': '10.23', 'feedthrough': 2, 'return': 10},
-          'pmt_position': 243,
-          'position': {'x': 1.1257790335278184, 'y': -44.52788588702218},
-          'serial_number': 852.0,
-          'signal': {'connector': '10.23', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 3, 'crate': 0, 'module': 127, 'slot': 19},
-          'high_voltage': {'connector': '9.20', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 244,
-          'position': {'x': 8.516815293618112, 'y': -41.46641842810146},
-          'serial_number': 845.0,
-          'signal': {'connector': '9.20', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 4, 'crate': 0, 'module': 1237, 'slot': 20},
-          'high_voltage': {'connector': '9.21', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 245,
-          'position': {'x': 15.907851553708406, 'y': -38.404950969180746},
-          'serial_number': 841.0,
-          'signal': {'connector': '9.21', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 4, 'crate': 0, 'module': 1236, 'slot': 18},
-          'high_voltage': {'connector': '9.22', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 246,
-          'position': {'x': 23.2988878137987, 'y': -35.34348351026003},
-          'serial_number': 834.0,
-          'signal': {'connector': '9.22', 'feedthrough': 3}},
-         {'array': 'bottom',
-          'digitizer': {'channel': 5, 'crate': 0, 'module': 127, 'slot': 19},
-          'high_voltage': {'connector': '9.23', 'feedthrough': 2, 'return': 9},
-          'pmt_position': 247,
-          'position': {'x': 30.689924073888996, 'y': -32.28201605133931},
-          'serial_number': 823.0,
-          'signal': {'connector': '9.23', 'feedthrough': 3}},
-         {'array': 'diagnostic',
-          'digitizer': {'channel': 4, 'crate': 0, 'module': 154, 'slot': 7},
-          'high_voltage': {'connector': '5.15', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 248,
-          'position': {'x': 0, 'y': 0},
-          'serial_number': -1,
-          'signal': {'connector': '5.15', 'feedthrough': 1}},
-         {'array': 'diagnostic',
-          'digitizer': {'channel': 4, 'crate': 0, 'module': 1239, 'slot': 6},
-          'high_voltage': {'connector': '5.16', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 249,
-          'position': {'x': 0, 'y': 0},
-          'serial_number': -1,
-          'signal': {'connector': '5.16', 'feedthrough': 1}},
-         {'array': 'diagnostic',
-          'digitizer': {'channel': 4, 'crate': 0, 'module': 153, 'slot': 5},
-          'high_voltage': {'connector': '5.17', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 250,
-          'position': {'x': 0, 'y': 0},
-          'serial_number': -1,
-          'signal': {'connector': '5.17', 'feedthrough': 1}},
-         {'array': 'diagnostic',
-          'digitizer': {'channel': 6, 'crate': 0, 'module': 154, 'slot': 7},
-          'high_voltage': {'connector': '5.18', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 251,
-          'position': {'x': 0, 'y': 0},
-          'serial_number': -1,
-          'signal': {'connector': '5.18', 'feedthrough': 1}},
-         {'array': 'diagnostic',
-          'digitizer': {'channel': 6, 'crate': 0, 'module': 1239, 'slot': 6},
-          'high_voltage': {'connector': '5.19', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 252,
-          'position': {'x': 0, 'y': 0},
-          'serial_number': -1,
-          'signal': {'connector': '5.19', 'feedthrough': 1}},
-         {'array': 'diagnostic',
-          'digitizer': {'channel': 6, 'crate': 0, 'module': 153, 'slot': 5},
-          'high_voltage': {'connector': '5.20', 'feedthrough': 1, 'return': 5},
-          'pmt_position': 253,
-          'position': {'x': 0, 'y': 0},
-          'serial_number': -1,
-          'signal': {'connector': '5.20', 'feedthrough': 1}}]
+pmts  = [
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 0,
+                    "module": 1244,
+                    "slot": 10
+                },
+                "high_voltage": {
+                    "channel": 5,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 0,
+                "position": {
+                    "x": -12.345668451390225,
+                    "y": 46.074661913988564
+                },
+                "serial_number": 511,
+                "signal": {
+                    "channel": 5,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 0,
+                    "module": 153,
+                    "slot": 5
+                },
+                "high_voltage": {
+                    "channel": 0,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 1,
+                "position": {
+                    "x": -4.157328929063286,
+                    "y": 47.518487098976266
+                },
+                "serial_number": 602,
+                "signal": {
+                    "channel": 0,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 0,
+                    "module": 1239,
+                    "slot": 6
+                },
+                "high_voltage": {
+                    "channel": 1,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 2,
+                "position": {
+                    "x": 4.1573289290632935,
+                    "y": 47.51848709897626
+                },
+                "serial_number": 513,
+                "signal": {
+                    "channel": 1,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 0,
+                    "module": 1239,
+                    "slot": 6
+                },
+                "high_voltage": {
+                    "channel": 2,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 3,
+                "position": {
+                    "x": 12.345668451390232,
+                    "y": 46.07466191398856
+                },
+                "serial_number": 479,
+                "signal": {
+                    "channel": 2,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 0,
+                    "module": 154,
+                    "slot": 7
+                },
+                "high_voltage": {
+                    "channel": 3,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 4,
+                "position": {
+                    "x": 20.158891085031385,
+                    "y": 43.230881441648194
+                },
+                "serial_number": 519,
+                "signal": {
+                    "channel": 3,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 0,
+                    "module": 153,
+                    "slot": 5
+                },
+                "high_voltage": {
+                    "channel": 4,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 5,
+                "position": {
+                    "x": 27.35959601394491,
+                    "y": 39.073552512584904
+                },
+                "serial_number": 419,
+                "signal": {
+                    "channel": 4,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 0,
+                    "module": 154,
+                    "slot": 7
+                },
+                "high_voltage": {
+                    "channel": 5,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 6,
+                "position": {
+                    "x": 33.72899346259835,
+                    "y": 33.72899346259829
+                },
+                "serial_number": 779,
+                "signal": {
+                    "channel": 5,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 1,
+                    "module": 1258,
+                    "slot": 16
+                },
+                "high_voltage": {
+                    "channel": 0,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 7,
+                "position": {
+                    "x": 39.073552512584904,
+                    "y": 27.359596013944902
+                },
+                "serial_number": 496,
+                "signal": {
+                    "channel": 0,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 1,
+                    "module": 1257,
+                    "slot": 14
+                },
+                "high_voltage": {
+                    "channel": 1,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 8,
+                "position": {
+                    "x": 43.23088144164822,
+                    "y": 20.158891085031343
+                },
+                "serial_number": 877,
+                "signal": {
+                    "channel": 1,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 1,
+                    "module": 1229,
+                    "slot": 15
+                },
+                "high_voltage": {
+                    "channel": 2,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 9,
+                "position": {
+                    "x": 46.074661913988564,
+                    "y": 12.345668451390226
+                },
+                "serial_number": 885,
+                "signal": {
+                    "channel": 2,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 1,
+                    "module": 1258,
+                    "slot": 16
+                },
+                "high_voltage": {
+                    "channel": 3,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 10,
+                "position": {
+                    "x": 47.518487098976266,
+                    "y": 4.157328929063288
+                },
+                "serial_number": 469,
+                "signal": {
+                    "channel": 3,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 1,
+                    "module": 1257,
+                    "slot": 14
+                },
+                "high_voltage": {
+                    "channel": 4,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 11,
+                "position": {
+                    "x": 47.51848709897626,
+                    "y": -4.157328929063292
+                },
+                "serial_number": 140,
+                "signal": {
+                    "channel": 4,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 1,
+                    "module": 1229,
+                    "slot": 15
+                },
+                "high_voltage": {
+                    "channel": 5,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 12,
+                "position": {
+                    "x": 46.07466191398855,
+                    "y": -12.34566845139027
+                },
+                "serial_number": 432,
+                "signal": {
+                    "channel": 5,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 1,
+                    "module": 1161,
+                    "slot": 3
+                },
+                "high_voltage": {
+                    "channel": 0,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 13,
+                "position": {
+                    "x": 43.230881441648194,
+                    "y": -20.158891085031378
+                },
+                "serial_number": 634,
+                "signal": {
+                    "channel": 0,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 1,
+                    "module": 1187,
+                    "slot": 7
+                },
+                "high_voltage": {
+                    "channel": 1,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 14,
+                "position": {
+                    "x": 39.07355251258489,
+                    "y": -27.359596013944923
+                },
+                "serial_number": 413,
+                "signal": {
+                    "channel": 1,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 1,
+                    "module": 1212,
+                    "slot": 5
+                },
+                "high_voltage": {
+                    "channel": 2,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 15,
+                "position": {
+                    "x": 33.72899346259832,
+                    "y": -33.72899346259832
+                },
+                "serial_number": 538,
+                "signal": {
+                    "channel": 2,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 1,
+                    "module": 1161,
+                    "slot": 3
+                },
+                "high_voltage": {
+                    "channel": 3,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 16,
+                "position": {
+                    "x": 27.35959601394489,
+                    "y": -39.07355251258491
+                },
+                "serial_number": 915,
+                "signal": {
+                    "channel": 3,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 1,
+                    "module": 1212,
+                    "slot": 5
+                },
+                "high_voltage": {
+                    "channel": 4,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 17,
+                "position": {
+                    "x": 20.158891085031346,
+                    "y": -43.23088144164822
+                },
+                "serial_number": 535,
+                "signal": {
+                    "channel": 4,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 1,
+                    "module": 1187,
+                    "slot": 7
+                },
+                "high_voltage": {
+                    "channel": 5,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 18,
+                "position": {
+                    "x": 12.34566845139023,
+                    "y": -46.074661913988564
+                },
+                "serial_number": 531,
+                "signal": {
+                    "channel": 5,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 0,
+                    "module": 1242,
+                    "slot": 8
+                },
+                "high_voltage": {
+                    "channel": 0,
+                    "connector": 4,
+                    "feedthrough": 1,
+                    "return": 4
+                },
+                "pmt_position": 19,
+                "position": {
+                    "x": 4.157328929063292,
+                    "y": -47.518487098976266
+                },
+                "serial_number": 447,
+                "signal": {
+                    "channel": 0,
+                    "connector": 4,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 0,
+                    "module": 156,
+                    "slot": 9
+                },
+                "high_voltage": {
+                    "channel": 1,
+                    "connector": 4,
+                    "feedthrough": 1,
+                    "return": 4
+                },
+                "pmt_position": 20,
+                "position": {
+                    "x": -4.1573289290633095,
+                    "y": -47.51848709897626
+                },
+                "serial_number": 444,
+                "signal": {
+                    "channel": 1,
+                    "connector": 4,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 0,
+                    "module": 154,
+                    "slot": 7
+                },
+                "high_voltage": {
+                    "channel": 2,
+                    "connector": 4,
+                    "feedthrough": 1,
+                    "return": 4
+                },
+                "pmt_position": 21,
+                "position": {
+                    "x": -12.345668451390264,
+                    "y": -46.07466191398856
+                },
+                "serial_number": 579,
+                "signal": {
+                    "channel": 2,
+                    "connector": 4,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 0,
+                    "module": 1239,
+                    "slot": 6
+                },
+                "high_voltage": {
+                    "channel": 3,
+                    "connector": 4,
+                    "feedthrough": 1,
+                    "return": 4
+                },
+                "pmt_position": 22,
+                "position": {
+                    "x": -20.158891085031378,
+                    "y": -43.230881441648194
+                },
+                "serial_number": 611,
+                "signal": {
+                    "channel": 3,
+                    "connector": 4,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 0,
+                    "module": 153,
+                    "slot": 5
+                },
+                "high_voltage": {
+                    "channel": 4,
+                    "connector": 4,
+                    "feedthrough": 1,
+                    "return": 4
+                },
+                "pmt_position": 23,
+                "position": {
+                    "x": -27.359596013944902,
+                    "y": -39.07355251258491
+                },
+                "serial_number": 614,
+                "signal": {
+                    "channel": 4,
+                    "connector": 4,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 0,
+                    "module": 1242,
+                    "slot": 8
+                },
+                "high_voltage": {
+                    "channel": 5,
+                    "connector": 4,
+                    "feedthrough": 1,
+                    "return": 4
+                },
+                "pmt_position": 24,
+                "position": {
+                    "x": -33.728993462598325,
+                    "y": -33.728993462598304
+                },
+                "serial_number": 553,
+                "signal": {
+                    "channel": 5,
+                    "connector": 4,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 1,
+                    "module": 1227,
+                    "slot": 13
+                },
+                "high_voltage": {
+                    "channel": 0,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 25,
+                "position": {
+                    "x": -39.07355251258492,
+                    "y": -27.359596013944888
+                },
+                "serial_number": 764,
+                "signal": {
+                    "channel": 0,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 1,
+                    "module": 1227,
+                    "slot": 13
+                },
+                "high_voltage": {
+                    "channel": 1,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 26,
+                "position": {
+                    "x": -43.23088144164821,
+                    "y": -20.158891085031357
+                },
+                "serial_number": 149,
+                "signal": {
+                    "channel": 1,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 1,
+                    "module": 1219,
+                    "slot": 11
+                },
+                "high_voltage": {
+                    "channel": 2,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 27,
+                "position": {
+                    "x": -46.074661913988564,
+                    "y": -12.345668451390232
+                },
+                "serial_number": 509,
+                "signal": {
+                    "channel": 2,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 1,
+                    "module": 1227,
+                    "slot": 13
+                },
+                "high_voltage": {
+                    "channel": 3,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 28,
+                "position": {
+                    "x": -47.518487098976266,
+                    "y": -4.157328929063286
+                },
+                "serial_number": 524,
+                "signal": {
+                    "channel": 3,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 1,
+                    "module": 1254,
+                    "slot": 12
+                },
+                "high_voltage": {
+                    "channel": 4,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 29,
+                "position": {
+                    "x": -47.51848709897626,
+                    "y": 4.157328929063306
+                },
+                "serial_number": 527,
+                "signal": {
+                    "channel": 4,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 1,
+                    "module": 1219,
+                    "slot": 11
+                },
+                "high_voltage": {
+                    "channel": 5,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 30,
+                "position": {
+                    "x": -46.07466191398856,
+                    "y": 12.345668451390251
+                },
+                "serial_number": 545,
+                "signal": {
+                    "channel": 5,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 0,
+                    "module": 876,
+                    "slot": 11
+                },
+                "high_voltage": {
+                    "channel": 0,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 31,
+                "position": {
+                    "x": -43.2308814416482,
+                    "y": 20.15889108503137
+                },
+                "serial_number": 508,
+                "signal": {
+                    "channel": 0,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 0,
+                    "module": 1244,
+                    "slot": 10
+                },
+                "high_voltage": {
+                    "channel": 1,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 32,
+                "position": {
+                    "x": -39.073552512584904,
+                    "y": 27.359596013944902
+                },
+                "serial_number": 471,
+                "signal": {
+                    "channel": 1,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 0,
+                    "module": 876,
+                    "slot": 11
+                },
+                "high_voltage": {
+                    "channel": 2,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 33,
+                "position": {
+                    "x": -33.72899346259831,
+                    "y": 33.72899346259832
+                },
+                "serial_number": 529,
+                "signal": {
+                    "channel": 2,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 0,
+                    "module": 1244,
+                    "slot": 10
+                },
+                "high_voltage": {
+                    "channel": 3,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 34,
+                "position": {
+                    "x": -27.359596013944895,
+                    "y": 39.07355251258491
+                },
+                "serial_number": 547,
+                "signal": {
+                    "channel": 3,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 0,
+                    "module": 1246,
+                    "slot": 12
+                },
+                "high_voltage": {
+                    "channel": 4,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 35,
+                "position": {
+                    "x": -20.158891085031357,
+                    "y": 43.23088144164821
+                },
+                "serial_number": 830,
+                "signal": {
+                    "channel": 4,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 0,
+                    "module": 1244,
+                    "slot": 10
+                },
+                "high_voltage": {
+                    "channel": 10,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 36,
+                "position": {
+                    "x": -10.288057042825152,
+                    "y": 38.39555159499048
+                },
+                "serial_number": 428,
+                "signal": {
+                    "channel": 10,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 0,
+                    "module": 1244,
+                    "slot": 10
+                },
+                "high_voltage": {
+                    "channel": 11,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 37,
+                "position": {
+                    "x": -2.0803542606570264,
+                    "y": 39.69552400649432
+                },
+                "serial_number": 745,
+                "signal": {
+                    "channel": 11,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 0,
+                    "module": 153,
+                    "slot": 5
+                },
+                "high_voltage": {
+                    "channel": 6,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 38,
+                "position": {
+                    "x": 6.218269985349179,
+                    "y": 39.260611538656725
+                },
+                "serial_number": 826,
+                "signal": {
+                    "channel": 6,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 0,
+                    "module": 1239,
+                    "slot": 6
+                },
+                "high_voltage": {
+                    "channel": 7,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 39,
+                "position": {
+                    "x": 14.245125994425699,
+                    "y": 37.10982195326377
+                },
+                "serial_number": 832,
+                "signal": {
+                    "channel": 7,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 0,
+                    "module": 1239,
+                    "slot": 6
+                },
+                "high_voltage": {
+                    "channel": 8,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 40,
+                "position": {
+                    "x": 21.64940164184732,
+                    "y": 33.33715507583061
+                },
+                "serial_number": 598,
+                "signal": {
+                    "channel": 8,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 0,
+                    "module": 154,
+                    "slot": 7
+                },
+                "high_voltage": {
+                    "channel": 9,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 41,
+                "position": {
+                    "x": 28.107494552165267,
+                    "y": 28.107494552165264
+                },
+                "serial_number": 455,
+                "signal": {
+                    "channel": 9,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 1,
+                    "module": 1257,
+                    "slot": 14
+                },
+                "high_voltage": {
+                    "channel": 6,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 42,
+                "position": {
+                    "x": 33.33715507583061,
+                    "y": 21.649401641847316
+                },
+                "serial_number": 153,
+                "signal": {
+                    "channel": 6,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 1,
+                    "module": 1257,
+                    "slot": 14
+                },
+                "high_voltage": {
+                    "channel": 7,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 43,
+                "position": {
+                    "x": 37.10982195326378,
+                    "y": 14.245125994425663
+                },
+                "serial_number": 448,
+                "signal": {
+                    "channel": 7,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 1,
+                    "module": 1229,
+                    "slot": 15
+                },
+                "high_voltage": {
+                    "channel": 8,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 44,
+                "position": {
+                    "x": 39.26061153865673,
+                    "y": 6.218269985349142
+                },
+                "serial_number": 211,
+                "signal": {
+                    "channel": 8,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 1,
+                    "module": 1257,
+                    "slot": 14
+                },
+                "high_voltage": {
+                    "channel": 9,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 45,
+                "position": {
+                    "x": 39.6955240064943,
+                    "y": -2.080354260657028
+                },
+                "serial_number": 506,
+                "signal": {
+                    "channel": 9,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 1,
+                    "module": 1258,
+                    "slot": 16
+                },
+                "high_voltage": {
+                    "channel": 10,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 46,
+                "position": {
+                    "x": 38.39555159499045,
+                    "y": -10.288057042825226
+                },
+                "serial_number": 417,
+                "signal": {
+                    "channel": 10,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 1,
+                    "module": 1212,
+                    "slot": 5
+                },
+                "high_voltage": {
+                    "channel": 6,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 47,
+                "position": {
+                    "x": 35.41750933648761,
+                    "y": -18.046122364647005
+                },
+                "serial_number": 549,
+                "signal": {
+                    "channel": 6,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 1,
+                    "module": 1161,
+                    "slot": 3
+                },
+                "high_voltage": {
+                    "channel": 7,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 48,
+                "position": {
+                    "x": 30.891551967914587,
+                    "y": -25.01548554423105
+                },
+                "serial_number": 667,
+                "signal": {
+                    "channel": 7,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 1,
+                    "module": 1187,
+                    "slot": 7
+                },
+                "high_voltage": {
+                    "channel": 8,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 49,
+                "position": {
+                    "x": 25.015485544231034,
+                    "y": -30.8915519679146
+                },
+                "serial_number": 790,
+                "signal": {
+                    "channel": 8,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 1,
+                    "module": 1249,
+                    "slot": 4
+                },
+                "high_voltage": {
+                    "channel": 9,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 50,
+                "position": {
+                    "x": 18.04612236464697,
+                    "y": -35.41750933648763
+                },
+                "serial_number": 824,
+                "signal": {
+                    "channel": 9,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 1,
+                    "module": 1250,
+                    "slot": 6
+                },
+                "high_voltage": {
+                    "channel": 10,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 51,
+                "position": {
+                    "x": 10.288057042825173,
+                    "y": -38.39555159499047
+                },
+                "serial_number": 825,
+                "signal": {
+                    "channel": 10,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 1,
+                    "module": 1249,
+                    "slot": 4
+                },
+                "high_voltage": {
+                    "channel": 11,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 52,
+                "position": {
+                    "x": 2.080354260657014,
+                    "y": -39.69552400649432
+                },
+                "serial_number": 507,
+                "signal": {
+                    "channel": 11,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 0,
+                    "module": 1242,
+                    "slot": 8
+                },
+                "high_voltage": {
+                    "channel": 6,
+                    "connector": 4,
+                    "feedthrough": 1,
+                    "return": 4
+                },
+                "pmt_position": 53,
+                "position": {
+                    "x": -6.218269985349176,
+                    "y": -39.260611538656725
+                },
+                "serial_number": 530,
+                "signal": {
+                    "channel": 6,
+                    "connector": 4,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 0,
+                    "module": 1242,
+                    "slot": 8
+                },
+                "high_voltage": {
+                    "channel": 7,
+                    "connector": 4,
+                    "feedthrough": 1,
+                    "return": 4
+                },
+                "pmt_position": 54,
+                "position": {
+                    "x": -14.245125994425695,
+                    "y": -37.10982195326377
+                },
+                "serial_number": 795,
+                "signal": {
+                    "channel": 7,
+                    "connector": 4,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 0,
+                    "module": 156,
+                    "slot": 9
+                },
+                "high_voltage": {
+                    "channel": 8,
+                    "connector": 4,
+                    "feedthrough": 1,
+                    "return": 4
+                },
+                "pmt_position": 55,
+                "position": {
+                    "x": -21.64940164184734,
+                    "y": -33.337155075830594
+                },
+                "serial_number": 421,
+                "signal": {
+                    "channel": 8,
+                    "connector": 4,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 0,
+                    "module": 156,
+                    "slot": 9
+                },
+                "high_voltage": {
+                    "channel": 9,
+                    "connector": 4,
+                    "feedthrough": 1,
+                    "return": 4
+                },
+                "pmt_position": 56,
+                "position": {
+                    "x": -28.10749455216527,
+                    "y": -28.107494552165253
+                },
+                "serial_number": 813,
+                "signal": {
+                    "channel": 9,
+                    "connector": 4,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 1,
+                    "module": 1254,
+                    "slot": 12
+                },
+                "high_voltage": {
+                    "channel": 6,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 57,
+                "position": {
+                    "x": -33.33715507583061,
+                    "y": -21.64940164184732
+                },
+                "serial_number": 472,
+                "signal": {
+                    "channel": 6,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 1,
+                    "module": 1254,
+                    "slot": 12
+                },
+                "high_voltage": {
+                    "channel": 7,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 58,
+                "position": {
+                    "x": -37.109821953263776,
+                    "y": -14.245125994425678
+                },
+                "serial_number": 487,
+                "signal": {
+                    "channel": 7,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 1,
+                    "module": 1219,
+                    "slot": 11
+                },
+                "high_voltage": {
+                    "channel": 8,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 59,
+                "position": {
+                    "x": -39.260611538656725,
+                    "y": -6.218269985349172
+                },
+                "serial_number": 564,
+                "signal": {
+                    "channel": 8,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 1,
+                    "module": 1254,
+                    "slot": 12
+                },
+                "high_voltage": {
+                    "channel": 9,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 60,
+                "position": {
+                    "x": -39.6955240064943,
+                    "y": 2.080354260657023
+                },
+                "serial_number": 610,
+                "signal": {
+                    "channel": 9,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 1,
+                    "module": 1219,
+                    "slot": 11
+                },
+                "high_voltage": {
+                    "channel": 10,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 61,
+                "position": {
+                    "x": -38.395551594990465,
+                    "y": 10.288057042825208
+                },
+                "serial_number": 655,
+                "signal": {
+                    "channel": 10,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 0,
+                    "module": 876,
+                    "slot": 11
+                },
+                "high_voltage": {
+                    "channel": 6,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 62,
+                "position": {
+                    "x": -35.41750933648762,
+                    "y": 18.04612236464699
+                },
+                "serial_number": 665,
+                "signal": {
+                    "channel": 6,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 0,
+                    "module": 1244,
+                    "slot": 10
+                },
+                "high_voltage": {
+                    "channel": 7,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 63,
+                "position": {
+                    "x": -30.891551967914587,
+                    "y": 25.01548554423104
+                },
+                "serial_number": 856,
+                "signal": {
+                    "channel": 7,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 0,
+                    "module": 1243,
+                    "slot": 13
+                },
+                "high_voltage": {
+                    "channel": 8,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 64,
+                "position": {
+                    "x": -25.015485544231034,
+                    "y": 30.8915519679146
+                },
+                "serial_number": 829,
+                "signal": {
+                    "channel": 8,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 0,
+                    "module": 1246,
+                    "slot": 12
+                },
+                "high_voltage": {
+                    "channel": 9,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 65,
+                "position": {
+                    "x": -18.04612236464698,
+                    "y": 35.41750933648763
+                },
+                "serial_number": 544,
+                "signal": {
+                    "channel": 9,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 0,
+                    "module": 876,
+                    "slot": 11
+                },
+                "high_voltage": {
+                    "channel": 15,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 66,
+                "position": {
+                    "x": -8.23044563426015,
+                    "y": 30.716441275992377
+                },
+                "serial_number": 683,
+                "signal": {
+                    "channel": 15,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 0,
+                    "module": 156,
+                    "slot": 9
+                },
+                "high_voltage": {
+                    "channel": 16,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 67,
+                "position": {
+                    "x": 3.108624468950438e-14,
+                    "y": 31.8
+                },
+                "serial_number": 712,
+                "signal": {
+                    "channel": 16,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 0,
+                    "module": 153,
+                    "slot": 5
+                },
+                "high_voltage": {
+                    "channel": 10,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 68,
+                "position": {
+                    "x": 8.230445634260182,
+                    "y": 30.716441275992366
+                },
+                "serial_number": 851,
+                "signal": {
+                    "channel": 10,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 0,
+                    "module": 1239,
+                    "slot": 6
+                },
+                "high_voltage": {
+                    "channel": 11,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 69,
+                "position": {
+                    "x": 15.90000000000001,
+                    "y": 27.53960784034514
+                },
+                "serial_number": 831,
+                "signal": {
+                    "channel": 11,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 1,
+                    "module": 1229,
+                    "slot": 15
+                },
+                "high_voltage": {
+                    "channel": 11,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 70,
+                "position": {
+                    "x": 22.485995641732213,
+                    "y": 22.485995641732213
+                },
+                "serial_number": 771,
+                "signal": {
+                    "channel": 11,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 1,
+                    "module": 1257,
+                    "slot": 14
+                },
+                "high_voltage": {
+                    "channel": 12,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 71,
+                "position": {
+                    "x": 27.53960784034516,
+                    "y": 15.899999999999984
+                },
+                "serial_number": 794,
+                "signal": {
+                    "channel": 12,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 1,
+                    "module": 1257,
+                    "slot": 14
+                },
+                "high_voltage": {
+                    "channel": 13,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 72,
+                "position": {
+                    "x": 30.716441275992374,
+                    "y": 8.230445634260152
+                },
+                "serial_number": 150,
+                "signal": {
+                    "channel": 13,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 1,
+                    "module": 1258,
+                    "slot": 16
+                },
+                "high_voltage": {
+                    "channel": 14,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 73,
+                "position": {
+                    "x": 31.8,
+                    "y": 0.0
+                },
+                "serial_number": 269,
+                "signal": {
+                    "channel": 14,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 1,
+                    "module": 1229,
+                    "slot": 15
+                },
+                "high_voltage": {
+                    "channel": 15,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 74,
+                "position": {
+                    "x": 30.716441275992366,
+                    "y": -8.230445634260182
+                },
+                "serial_number": 711,
+                "signal": {
+                    "channel": 15,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 1,
+                    "module": 1250,
+                    "slot": 6
+                },
+                "high_voltage": {
+                    "channel": 12,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 75,
+                "position": {
+                    "x": 27.539607840345138,
+                    "y": -15.90000000000002
+                },
+                "serial_number": 811,
+                "signal": {
+                    "channel": 12,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 1,
+                    "module": 1249,
+                    "slot": 4
+                },
+                "high_voltage": {
+                    "channel": 13,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 76,
+                "position": {
+                    "x": 22.485995641732202,
+                    "y": -22.485995641732224
+                },
+                "serial_number": 917,
+                "signal": {
+                    "channel": 13,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 0,
+                    "module": 1234,
+                    "slot": 16
+                },
+                "high_voltage": {
+                    "channel": 14,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 77,
+                "position": {
+                    "x": 15.899999999999999,
+                    "y": -27.539607840345152
+                },
+                "serial_number": 883,
+                "signal": {
+                    "channel": 14,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 0,
+                    "module": 110,
+                    "slot": 15
+                },
+                "high_voltage": {
+                    "channel": 15,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 78,
+                "position": {
+                    "x": 8.230445634260153,
+                    "y": -30.716441275992374
+                },
+                "serial_number": 649,
+                "signal": {
+                    "channel": 15,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 0,
+                    "module": 1234,
+                    "slot": 16
+                },
+                "high_voltage": {
+                    "channel": 16,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 79,
+                "position": {
+                    "x": -1.3322676295501878e-14,
+                    "y": -31.8
+                },
+                "serial_number": 708,
+                "signal": {
+                    "channel": 16,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 0,
+                    "module": 1242,
+                    "slot": 8
+                },
+                "high_voltage": {
+                    "channel": 10,
+                    "connector": 4,
+                    "feedthrough": 1,
+                    "return": 4
+                },
+                "pmt_position": 80,
+                "position": {
+                    "x": -8.230445634260162,
+                    "y": -30.716441275992374
+                },
+                "serial_number": 766,
+                "signal": {
+                    "channel": 10,
+                    "connector": 4,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 0,
+                    "module": 156,
+                    "slot": 9
+                },
+                "high_voltage": {
+                    "channel": 11,
+                    "connector": 4,
+                    "feedthrough": 1,
+                    "return": 4
+                },
+                "pmt_position": 81,
+                "position": {
+                    "x": -15.900000000000006,
+                    "y": -27.539607840345145
+                },
+                "serial_number": 814,
+                "signal": {
+                    "channel": 11,
+                    "connector": 4,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 1,
+                    "module": 1254,
+                    "slot": 12
+                },
+                "high_voltage": {
+                    "channel": 11,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 82,
+                "position": {
+                    "x": -22.485995641732217,
+                    "y": -22.485995641732202
+                },
+                "serial_number": 812,
+                "signal": {
+                    "channel": 11,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 1,
+                    "module": 1227,
+                    "slot": 13
+                },
+                "high_voltage": {
+                    "channel": 12,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 83,
+                "position": {
+                    "x": -27.539607840345152,
+                    "y": -15.899999999999993
+                },
+                "serial_number": 928,
+                "signal": {
+                    "channel": 12,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 1,
+                    "module": 1219,
+                    "slot": 11
+                },
+                "high_voltage": {
+                    "channel": 13,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 84,
+                "position": {
+                    "x": -30.716441275992374,
+                    "y": -8.230445634260155
+                },
+                "serial_number": 213,
+                "signal": {
+                    "channel": 13,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 1,
+                    "module": 1227,
+                    "slot": 13
+                },
+                "high_voltage": {
+                    "channel": 14,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 85,
+                "position": {
+                    "x": -31.8,
+                    "y": 3.552713678800501e-15
+                },
+                "serial_number": 546,
+                "signal": {
+                    "channel": 14,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 1,
+                    "module": 1227,
+                    "slot": 13
+                },
+                "high_voltage": {
+                    "channel": 15,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 86,
+                "position": {
+                    "x": -30.71644127599237,
+                    "y": 8.230445634260168
+                },
+                "serial_number": 205,
+                "signal": {
+                    "channel": 15,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 0,
+                    "module": 1244,
+                    "slot": 10
+                },
+                "high_voltage": {
+                    "channel": 12,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 87,
+                "position": {
+                    "x": -27.539607840345145,
+                    "y": 15.900000000000006
+                },
+                "serial_number": 543,
+                "signal": {
+                    "channel": 12,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 0,
+                    "module": 1246,
+                    "slot": 12
+                },
+                "high_voltage": {
+                    "channel": 13,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 88,
+                "position": {
+                    "x": -22.48599564173221,
+                    "y": 22.485995641732217
+                },
+                "serial_number": 828,
+                "signal": {
+                    "channel": 13,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 0,
+                    "module": 876,
+                    "slot": 11
+                },
+                "high_voltage": {
+                    "channel": 14,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 89,
+                "position": {
+                    "x": -15.899999999999997,
+                    "y": 27.539607840345152
+                },
+                "serial_number": 151,
+                "signal": {
+                    "channel": 14,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 0,
+                    "module": 1243,
+                    "slot": 13
+                },
+                "high_voltage": {
+                    "channel": 19,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 90,
+                "position": {
+                    "x": -6.172834225695112,
+                    "y": 23.037330956994282
+                },
+                "serial_number": 207,
+                "signal": {
+                    "channel": 19,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 0,
+                    "module": 876,
+                    "slot": 11
+                },
+                "high_voltage": {
+                    "channel": 20,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 91,
+                "position": {
+                    "x": 2.0786644645316468,
+                    "y": 23.75924354948813
+                },
+                "serial_number": 765,
+                "signal": {
+                    "channel": 20,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 0,
+                    "module": 154,
+                    "slot": 7
+                },
+                "high_voltage": {
+                    "channel": 12,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 92,
+                "position": {
+                    "x": 10.079445542515693,
+                    "y": 21.615440720824097
+                },
+                "serial_number": 793,
+                "signal": {
+                    "channel": 12,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 1,
+                    "module": 1257,
+                    "slot": 14
+                },
+                "high_voltage": {
+                    "channel": 16,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 93,
+                "position": {
+                    "x": 16.864496731299177,
+                    "y": 16.864496731299145
+                },
+                "serial_number": 656,
+                "signal": {
+                    "channel": 16,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 1,
+                    "module": 1229,
+                    "slot": 15
+                },
+                "high_voltage": {
+                    "channel": 17,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 94,
+                "position": {
+                    "x": 21.61544072082411,
+                    "y": 10.079445542515671
+                },
+                "serial_number": 669,
+                "signal": {
+                    "channel": 17,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 1,
+                    "module": 1229,
+                    "slot": 15
+                },
+                "high_voltage": {
+                    "channel": 18,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 95,
+                "position": {
+                    "x": 23.759243549488133,
+                    "y": 2.078664464531644
+                },
+                "serial_number": 827,
+                "signal": {
+                    "channel": 18,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 1,
+                    "module": 1258,
+                    "slot": 16
+                },
+                "high_voltage": {
+                    "channel": 19,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 96,
+                "position": {
+                    "x": 23.037330956994275,
+                    "y": -6.172834225695135
+                },
+                "serial_number": 850,
+                "signal": {
+                    "channel": 19,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 0,
+                    "module": 117,
+                    "slot": 17
+                },
+                "high_voltage": {
+                    "channel": 17,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 97,
+                "position": {
+                    "x": 19.536776256292445,
+                    "y": -13.679798006972462
+                },
+                "serial_number": 923,
+                "signal": {
+                    "channel": 17,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 0,
+                    "module": 117,
+                    "slot": 17
+                },
+                "high_voltage": {
+                    "channel": 18,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 98,
+                "position": {
+                    "x": 13.679798006972446,
+                    "y": -19.536776256292455
+                },
+                "serial_number": 254,
+                "signal": {
+                    "channel": 18,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 0,
+                    "module": 1234,
+                    "slot": 16
+                },
+                "high_voltage": {
+                    "channel": 19,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 99,
+                "position": {
+                    "x": 6.172834225695115,
+                    "y": -23.037330956994282
+                },
+                "serial_number": 558,
+                "signal": {
+                    "channel": 19,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 0,
+                    "module": 1233,
+                    "slot": 14
+                },
+                "high_voltage": {
+                    "channel": 20,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 100,
+                "position": {
+                    "x": -2.0786644645316548,
+                    "y": -23.75924354948813
+                },
+                "serial_number": 219,
+                "signal": {
+                    "channel": 20,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 0,
+                    "module": 1242,
+                    "slot": 8
+                },
+                "high_voltage": {
+                    "channel": 12,
+                    "connector": 4,
+                    "feedthrough": 1,
+                    "return": 4
+                },
+                "pmt_position": 101,
+                "position": {
+                    "x": -10.079445542515689,
+                    "y": -21.615440720824097
+                },
+                "serial_number": 152,
+                "signal": {
+                    "channel": 12,
+                    "connector": 4,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 1,
+                    "module": 1254,
+                    "slot": 12
+                },
+                "high_voltage": {
+                    "channel": 16,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 102,
+                "position": {
+                    "x": -16.864496731299162,
+                    "y": -16.864496731299152
+                },
+                "serial_number": 687,
+                "signal": {
+                    "channel": 16,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 1,
+                    "module": 1227,
+                    "slot": 13
+                },
+                "high_voltage": {
+                    "channel": 17,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 103,
+                "position": {
+                    "x": -21.615440720824104,
+                    "y": -10.079445542515678
+                },
+                "serial_number": 925,
+                "signal": {
+                    "channel": 17,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 1,
+                    "module": 1254,
+                    "slot": 12
+                },
+                "high_voltage": {
+                    "channel": 18,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 104,
+                "position": {
+                    "x": -23.759243549488133,
+                    "y": -2.078664464531643
+                },
+                "serial_number": 670,
+                "signal": {
+                    "channel": 18,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 1,
+                    "module": 1219,
+                    "slot": 11
+                },
+                "high_voltage": {
+                    "channel": 19,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 105,
+                "position": {
+                    "x": -23.03733095699428,
+                    "y": 6.172834225695126
+                },
+                "serial_number": 718,
+                "signal": {
+                    "channel": 19,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 0,
+                    "module": 1244,
+                    "slot": 10
+                },
+                "high_voltage": {
+                    "channel": 17,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 106,
+                "position": {
+                    "x": -19.536776256292452,
+                    "y": 13.679798006972451
+                },
+                "serial_number": 873,
+                "signal": {
+                    "channel": 17,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 0,
+                    "module": 876,
+                    "slot": 11
+                },
+                "high_voltage": {
+                    "channel": 18,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 107,
+                "position": {
+                    "x": -13.679798006972447,
+                    "y": 19.536776256292455
+                },
+                "serial_number": 924,
+                "signal": {
+                    "channel": 18,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 0,
+                    "module": 156,
+                    "slot": 9
+                },
+                "high_voltage": {
+                    "channel": 22,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 108,
+                "position": {
+                    "x": -4.115222817130075,
+                    "y": 15.358220637996189
+                },
+                "serial_number": 903,
+                "signal": {
+                    "channel": 22,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 0,
+                    "module": 154,
+                    "slot": 7
+                },
+                "high_voltage": {
+                    "channel": 13,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 109,
+                "position": {
+                    "x": 4.115222817130091,
+                    "y": 15.358220637996183
+                },
+                "serial_number": 220,
+                "signal": {
+                    "channel": 13,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 1,
+                    "module": 1258,
+                    "slot": 16
+                },
+                "high_voltage": {
+                    "channel": 20,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 110,
+                "position": {
+                    "x": 11.242997820866107,
+                    "y": 11.242997820866107
+                },
+                "serial_number": 229,
+                "signal": {
+                    "channel": 20,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 1,
+                    "module": 1229,
+                    "slot": 15
+                },
+                "high_voltage": {
+                    "channel": 21,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 111,
+                "position": {
+                    "x": 15.358220637996187,
+                    "y": 4.115222817130076
+                },
+                "serial_number": 761,
+                "signal": {
+                    "channel": 21,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 1,
+                    "module": 1258,
+                    "slot": 16
+                },
+                "high_voltage": {
+                    "channel": 22,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 112,
+                "position": {
+                    "x": 15.358220637996183,
+                    "y": -4.115222817130091
+                },
+                "serial_number": 816,
+                "signal": {
+                    "channel": 22,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 0,
+                    "module": 117,
+                    "slot": 17
+                },
+                "high_voltage": {
+                    "channel": 21,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 113,
+                "position": {
+                    "x": 11.242997820866101,
+                    "y": -11.242997820866112
+                },
+                "serial_number": 912,
+                "signal": {
+                    "channel": 21,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 0,
+                    "module": 1234,
+                    "slot": 16
+                },
+                "high_voltage": {
+                    "channel": 22,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 114,
+                "position": {
+                    "x": 4.115222817130077,
+                    "y": -15.358220637996187
+                },
+                "serial_number": 920,
+                "signal": {
+                    "channel": 22,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 0,
+                    "module": 156,
+                    "slot": 9
+                },
+                "high_voltage": {
+                    "channel": 13,
+                    "connector": 4,
+                    "feedthrough": 1,
+                    "return": 4
+                },
+                "pmt_position": 115,
+                "position": {
+                    "x": -4.115222817130081,
+                    "y": -15.358220637996187
+                },
+                "serial_number": 146,
+                "signal": {
+                    "channel": 13,
+                    "connector": 4,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 1,
+                    "module": 1227,
+                    "slot": 13
+                },
+                "high_voltage": {
+                    "channel": 20,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 116,
+                "position": {
+                    "x": -11.242997820866108,
+                    "y": -11.242997820866101
+                },
+                "serial_number": 154,
+                "signal": {
+                    "channel": 20,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 1,
+                    "module": 1219,
+                    "slot": 11
+                },
+                "high_voltage": {
+                    "channel": 21,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 117,
+                "position": {
+                    "x": -15.358220637996187,
+                    "y": -4.1152228171300775
+                },
+                "serial_number": 556,
+                "signal": {
+                    "channel": 21,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 1,
+                    "module": 1219,
+                    "slot": 11
+                },
+                "high_voltage": {
+                    "channel": 22,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 118,
+                "position": {
+                    "x": -15.358220637996185,
+                    "y": 4.115222817130084
+                },
+                "serial_number": 541,
+                "signal": {
+                    "channel": 22,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 0,
+                    "module": 876,
+                    "slot": 11
+                },
+                "high_voltage": {
+                    "channel": 21,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 119,
+                "position": {
+                    "x": -11.242997820866105,
+                    "y": 11.242997820866108
+                },
+                "serial_number": 616,
+                "signal": {
+                    "channel": 21,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 0,
+                    "module": 156,
+                    "slot": 9
+                },
+                "high_voltage": {
+                    "channel": 23,
+                    "connector": 3,
+                    "feedthrough": 0,
+                    "return": 3
+                },
+                "pmt_position": 120,
+                "position": {
+                    "x": -2.0576114085650374,
+                    "y": 7.679110318998094
+                },
+                "serial_number": 818,
+                "signal": {
+                    "channel": 23,
+                    "connector": 3,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 0,
+                    "module": 153,
+                    "slot": 5
+                },
+                "high_voltage": {
+                    "channel": 14,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 121,
+                "position": {
+                    "x": 5.621498910433053,
+                    "y": 5.621498910433053
+                },
+                "serial_number": 872,
+                "signal": {
+                    "channel": 14,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 1,
+                    "module": 1258,
+                    "slot": 16
+                },
+                "high_voltage": {
+                    "channel": 23,
+                    "connector": 0,
+                    "feedthrough": 0,
+                    "return": 0
+                },
+                "pmt_position": 122,
+                "position": {
+                    "x": 7.679110318998092,
+                    "y": -2.0576114085650454
+                },
+                "serial_number": 210,
+                "signal": {
+                    "channel": 23,
+                    "connector": 0,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 0,
+                    "module": 117,
+                    "slot": 17
+                },
+                "high_voltage": {
+                    "channel": 23,
+                    "connector": 2,
+                    "feedthrough": 0,
+                    "return": 2
+                },
+                "pmt_position": 123,
+                "position": {
+                    "x": 2.0576114085650383,
+                    "y": -7.679110318998093
+                },
+                "serial_number": 227,
+                "signal": {
+                    "channel": 23,
+                    "connector": 2,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 0,
+                    "module": 1242,
+                    "slot": 8
+                },
+                "high_voltage": {
+                    "channel": 14,
+                    "connector": 4,
+                    "feedthrough": 1,
+                    "return": 4
+                },
+                "pmt_position": 124,
+                "position": {
+                    "x": -5.621498910433054,
+                    "y": -5.621498910433051
+                },
+                "serial_number": 202,
+                "signal": {
+                    "channel": 14,
+                    "connector": 4,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 1,
+                    "module": 1254,
+                    "slot": 12
+                },
+                "high_voltage": {
+                    "channel": 23,
+                    "connector": 1,
+                    "feedthrough": 0,
+                    "return": 1
+                },
+                "pmt_position": 125,
+                "position": {
+                    "x": -7.6791103189980925,
+                    "y": 2.057611408565042
+                },
+                "serial_number": 231,
+                "signal": {
+                    "channel": 23,
+                    "connector": 1,
+                    "feedthrough": 0
+                }
+            },
+            {
+                "array": "top",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 0,
+                    "module": 1242,
+                    "slot": 8
+                },
+                "high_voltage": {
+                    "channel": 15,
+                    "connector": 4,
+                    "feedthrough": 1,
+                    "return": 4
+                },
+                "pmt_position": 126,
+                "position": {
+                    "x": 0.0,
+                    "y": 0.0
+                },
+                "serial_number": 752,
+                "signal": {
+                    "channel": 15,
+                    "connector": 4,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 1,
+                    "module": 1161,
+                    "slot": 3
+                },
+                "high_voltage": {
+                    "channel": 0,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 127,
+                "position": {
+                    "x": -30.689924073888996,
+                    "y": 32.28201605133931
+                },
+                "serial_number": 806,
+                "signal": {
+                    "channel": 0,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 1,
+                    "module": 1187,
+                    "slot": 7
+                },
+                "high_voltage": {
+                    "channel": 1,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 128,
+                "position": {
+                    "x": -23.2988878137987,
+                    "y": 35.34348351026003
+                },
+                "serial_number": 175,
+                "signal": {
+                    "channel": 1,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 1,
+                    "module": 1187,
+                    "slot": 7
+                },
+                "high_voltage": {
+                    "channel": 2,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 129,
+                "position": {
+                    "x": -15.907851553708406,
+                    "y": 38.404950969180746
+                },
+                "serial_number": 163,
+                "signal": {
+                    "channel": 2,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 1,
+                    "module": 1249,
+                    "slot": 4
+                },
+                "high_voltage": {
+                    "channel": 3,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 130,
+                "position": {
+                    "x": -8.516815293618112,
+                    "y": 41.46641842810146
+                },
+                "serial_number": 742,
+                "signal": {
+                    "channel": 3,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 1,
+                    "module": 1187,
+                    "slot": 7
+                },
+                "high_voltage": {
+                    "channel": 4,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 131,
+                "position": {
+                    "x": -1.1257790335278184,
+                    "y": 44.52788588702218
+                },
+                "serial_number": 751,
+                "signal": {
+                    "channel": 4,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 1,
+                    "module": 1092,
+                    "slot": 1
+                },
+                "high_voltage": {
+                    "channel": 0,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 132,
+                "position": {
+                    "x": -39.1251698717397,
+                    "y": 21.2889897014281
+                },
+                "serial_number": 854,
+                "signal": {
+                    "channel": 0,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 1,
+                    "module": 1247,
+                    "slot": 2
+                },
+                "high_voltage": {
+                    "channel": 1,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 133,
+                "position": {
+                    "x": -31.734133611649405,
+                    "y": 24.35045716034882
+                },
+                "serial_number": 124,
+                "signal": {
+                    "channel": 1,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 1,
+                    "module": 1212,
+                    "slot": 5
+                },
+                "high_voltage": {
+                    "channel": 5,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 134,
+                "position": {
+                    "x": -24.34309735155911,
+                    "y": 27.41192461926954
+                },
+                "serial_number": 123,
+                "signal": {
+                    "channel": 5,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 1,
+                    "module": 1249,
+                    "slot": 4
+                },
+                "high_voltage": {
+                    "channel": 6,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 135,
+                "position": {
+                    "x": -16.952061091468817,
+                    "y": 30.47339207819026
+                },
+                "serial_number": 668,
+                "signal": {
+                    "channel": 6,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 1,
+                    "module": 1212,
+                    "slot": 5
+                },
+                "high_voltage": {
+                    "channel": 7,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 136,
+                "position": {
+                    "x": -9.561024831378525,
+                    "y": 33.534859537110975
+                },
+                "serial_number": 754,
+                "signal": {
+                    "channel": 7,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 1,
+                    "module": 1249,
+                    "slot": 4
+                },
+                "high_voltage": {
+                    "channel": 8,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 137,
+                "position": {
+                    "x": -2.169988571288231,
+                    "y": 36.59632699603169
+                },
+                "serial_number": 904,
+                "signal": {
+                    "channel": 8,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 1,
+                    "module": 1212,
+                    "slot": 5
+                },
+                "high_voltage": {
+                    "channel": 9,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 138,
+                "position": {
+                    "x": 5.221047688802065,
+                    "y": 39.65779445495241
+                },
+                "serial_number": 855,
+                "signal": {
+                    "channel": 9,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 1,
+                    "module": 1161,
+                    "slot": 3
+                },
+                "high_voltage": {
+                    "channel": 10,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 139,
+                "position": {
+                    "x": 12.612083948892357,
+                    "y": 42.71926191387313
+                },
+                "serial_number": 760,
+                "signal": {
+                    "channel": 10,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 1,
+                    "module": 1247,
+                    "slot": 2
+                },
+                "high_voltage": {
+                    "channel": 2,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 140,
+                "position": {
+                    "x": -40.16937940950011,
+                    "y": 13.357430810437622
+                },
+                "serial_number": 809,
+                "signal": {
+                    "channel": 2,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 1,
+                    "module": 1247,
+                    "slot": 2
+                },
+                "high_voltage": {
+                    "channel": 3,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 141,
+                "position": {
+                    "x": -32.77834314940982,
+                    "y": 16.41889826935834
+                },
+                "serial_number": 170,
+                "signal": {
+                    "channel": 3,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 1,
+                    "module": 1092,
+                    "slot": 1
+                },
+                "high_voltage": {
+                    "channel": 4,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 142,
+                "position": {
+                    "x": -25.387306889319525,
+                    "y": 19.480365728279057
+                },
+                "serial_number": 785,
+                "signal": {
+                    "channel": 4,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 1,
+                    "module": 1250,
+                    "slot": 6
+                },
+                "high_voltage": {
+                    "channel": 11,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 143,
+                "position": {
+                    "x": -17.99627062922923,
+                    "y": 22.541833187199778
+                },
+                "serial_number": 215,
+                "signal": {
+                    "channel": 11,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 1,
+                    "module": 1250,
+                    "slot": 6
+                },
+                "high_voltage": {
+                    "channel": 12,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 144,
+                "position": {
+                    "x": -10.605234369138937,
+                    "y": 25.603300646120495
+                },
+                "serial_number": 122,
+                "signal": {
+                    "channel": 12,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 1,
+                    "module": 1212,
+                    "slot": 5
+                },
+                "high_voltage": {
+                    "channel": 13,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 145,
+                "position": {
+                    "x": -3.2141981090486436,
+                    "y": 28.66476810504121
+                },
+                "serial_number": 125,
+                "signal": {
+                    "channel": 13,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 1,
+                    "module": 1249,
+                    "slot": 4
+                },
+                "high_voltage": {
+                    "channel": 14,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 146,
+                "position": {
+                    "x": 4.17683815104165,
+                    "y": 31.726235563961932
+                },
+                "serial_number": 786,
+                "signal": {
+                    "channel": 14,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 1,
+                    "module": 1212,
+                    "slot": 5
+                },
+                "high_voltage": {
+                    "channel": 15,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 147,
+                "position": {
+                    "x": 11.567874411131942,
+                    "y": 34.78770302288265
+                },
+                "serial_number": 501,
+                "signal": {
+                    "channel": 15,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 0,
+                    "module": 1233,
+                    "slot": 14
+                },
+                "high_voltage": {
+                    "channel": 21,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 148,
+                "position": {
+                    "x": 18.958910671222238,
+                    "y": 37.84917048180337
+                },
+                "serial_number": 767,
+                "signal": {
+                    "channel": 15,
+                    "connector": 11,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 1,
+                    "module": 1092,
+                    "slot": 1
+                },
+                "high_voltage": {
+                    "channel": 5,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 149,
+                "position": {
+                    "x": -41.213588947260526,
+                    "y": 5.425871919447141
+                },
+                "serial_number": 926,
+                "signal": {
+                    "channel": 5,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 1,
+                    "module": 1247,
+                    "slot": 2
+                },
+                "high_voltage": {
+                    "channel": 6,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 150,
+                "position": {
+                    "x": -33.82255268717023,
+                    "y": 8.487339378367858
+                },
+                "serial_number": 204,
+                "signal": {
+                    "channel": 6,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 1,
+                    "module": 1247,
+                    "slot": 2
+                },
+                "high_voltage": {
+                    "channel": 7,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 151,
+                "position": {
+                    "x": -26.431516427079938,
+                    "y": 11.548806837288577
+                },
+                "serial_number": 777,
+                "signal": {
+                    "channel": 7,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 1,
+                    "module": 1092,
+                    "slot": 1
+                },
+                "high_voltage": {
+                    "channel": 8,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 152,
+                "position": {
+                    "x": -19.040480166989642,
+                    "y": 14.610274296209296
+                },
+                "serial_number": 743,
+                "signal": {
+                    "channel": 8,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 1,
+                    "module": 1161,
+                    "slot": 3
+                },
+                "high_voltage": {
+                    "channel": 16,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 153,
+                "position": {
+                    "x": -11.64944390689935,
+                    "y": 17.671741755130014
+                },
+                "serial_number": 787,
+                "signal": {
+                    "channel": 16,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 1,
+                    "module": 1187,
+                    "slot": 7
+                },
+                "high_voltage": {
+                    "channel": 17,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 154,
+                "position": {
+                    "x": -4.258407646809056,
+                    "y": 20.73320921405073
+                },
+                "serial_number": 134,
+                "signal": {
+                    "channel": 17,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 1,
+                    "module": 1249,
+                    "slot": 4
+                },
+                "high_voltage": {
+                    "channel": 18,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 155,
+                "position": {
+                    "x": 3.132628613281237,
+                    "y": 23.79467667297145
+                },
+                "serial_number": 135,
+                "signal": {
+                    "channel": 18,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 1,
+                    "module": 1250,
+                    "slot": 6
+                },
+                "high_voltage": {
+                    "channel": 19,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 156,
+                "position": {
+                    "x": 10.523664873371533,
+                    "y": 26.85614413189217
+                },
+                "serial_number": 121,
+                "signal": {
+                    "channel": 19,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 1,
+                    "module": 1251,
+                    "slot": 8
+                },
+                "high_voltage": {
+                    "channel": 0,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 157,
+                "position": {
+                    "x": 17.914701133461826,
+                    "y": 29.91761159081289
+                },
+                "serial_number": 679,
+                "signal": {
+                    "channel": 0,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 1,
+                    "module": 1216,
+                    "slot": 9
+                },
+                "high_voltage": {
+                    "channel": 1,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 158,
+                "position": {
+                    "x": 25.305737393552118,
+                    "y": 32.979079049733606
+                },
+                "serial_number": 768,
+                "signal": {
+                    "channel": 1,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 1,
+                    "module": 1092,
+                    "slot": 1
+                },
+                "high_voltage": {
+                    "channel": 9,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 159,
+                "position": {
+                    "x": -42.25779848502094,
+                    "y": -2.5056869715433443
+                },
+                "serial_number": 916,
+                "signal": {
+                    "channel": 9,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 1,
+                    "module": 1247,
+                    "slot": 2
+                },
+                "high_voltage": {
+                    "channel": 10,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 160,
+                "position": {
+                    "x": -34.866762224930646,
+                    "y": 0.5557804873773744
+                },
+                "serial_number": 203,
+                "signal": {
+                    "channel": 10,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 1,
+                    "module": 1092,
+                    "slot": 1
+                },
+                "high_voltage": {
+                    "channel": 11,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 161,
+                "position": {
+                    "x": -27.47572596484035,
+                    "y": 3.617247946298093
+                },
+                "serial_number": 196,
+                "signal": {
+                    "channel": 11,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 1,
+                    "module": 1247,
+                    "slot": 2
+                },
+                "high_voltage": {
+                    "channel": 12,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 162,
+                "position": {
+                    "x": -20.084689704750055,
+                    "y": 6.678715405218811
+                },
+                "serial_number": 183,
+                "signal": {
+                    "channel": 12,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 1,
+                    "module": 1247,
+                    "slot": 2
+                },
+                "high_voltage": {
+                    "channel": 13,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 163,
+                "position": {
+                    "x": -12.693653444659763,
+                    "y": 9.740182864139529
+                },
+                "serial_number": 113,
+                "signal": {
+                    "channel": 13,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 1,
+                    "module": 1161,
+                    "slot": 3
+                },
+                "high_voltage": {
+                    "channel": 20,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 164,
+                "position": {
+                    "x": -5.302617184569469,
+                    "y": 12.801650323060247
+                },
+                "serial_number": 127,
+                "signal": {
+                    "channel": 20,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 1,
+                    "module": 1161,
+                    "slot": 3
+                },
+                "high_voltage": {
+                    "channel": 21,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 165,
+                "position": {
+                    "x": 2.088419075520825,
+                    "y": 15.863117781980966
+                },
+                "serial_number": 120,
+                "signal": {
+                    "channel": 21,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 1,
+                    "module": 1250,
+                    "slot": 6
+                },
+                "high_voltage": {
+                    "channel": 22,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 166,
+                "position": {
+                    "x": 9.479455335611119,
+                    "y": 18.924585240901685
+                },
+                "serial_number": 218,
+                "signal": {
+                    "channel": 22,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 1,
+                    "module": 1216,
+                    "slot": 9
+                },
+                "high_voltage": {
+                    "channel": 2,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 167,
+                "position": {
+                    "x": 16.87049159570141,
+                    "y": 21.9860526998224
+                },
+                "serial_number": 148,
+                "signal": {
+                    "channel": 2,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 1,
+                    "module": 1251,
+                    "slot": 8
+                },
+                "high_voltage": {
+                    "channel": 3,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 168,
+                "position": {
+                    "x": 24.261527855791705,
+                    "y": 25.04752015874312
+                },
+                "serial_number": 206,
+                "signal": {
+                    "channel": 3,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 1,
+                    "module": 1251,
+                    "slot": 8
+                },
+                "high_voltage": {
+                    "channel": 4,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 169,
+                "position": {
+                    "x": 31.652564115882,
+                    "y": 28.10898761766384
+                },
+                "serial_number": 772,
+                "signal": {
+                    "channel": 4,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 1,
+                    "module": 1092,
+                    "slot": 1
+                },
+                "high_voltage": {
+                    "channel": 14,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 170,
+                "position": {
+                    "x": -43.30200802278135,
+                    "y": -10.437245862533826
+                },
+                "serial_number": 901,
+                "signal": {
+                    "channel": 14,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 1,
+                    "module": 1092,
+                    "slot": 1
+                },
+                "high_voltage": {
+                    "channel": 15,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 171,
+                "position": {
+                    "x": -35.910971762691055,
+                    "y": -7.375778403613108
+                },
+                "serial_number": 173,
+                "signal": {
+                    "channel": 15,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 0,
+                    "module": 1234,
+                    "slot": 16
+                },
+                "high_voltage": {
+                    "channel": 16,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 172,
+                "position": {
+                    "x": -28.519935502600763,
+                    "y": -4.314310944692391
+                },
+                "serial_number": 801,
+                "signal": {
+                    "channel": 16,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 0,
+                    "module": 117,
+                    "slot": 17
+                },
+                "high_voltage": {
+                    "channel": 17,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 173,
+                "position": {
+                    "x": -21.12889924251047,
+                    "y": -1.2528434857716721
+                },
+                "serial_number": 166,
+                "signal": {
+                    "channel": 17,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 0,
+                    "module": 117,
+                    "slot": 17
+                },
+                "high_voltage": {
+                    "channel": 18,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 174,
+                "position": {
+                    "x": -13.737862982420175,
+                    "y": 1.8086239731490465
+                },
+                "serial_number": 109,
+                "signal": {
+                    "channel": 18,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 0,
+                    "module": 1234,
+                    "slot": 16
+                },
+                "high_voltage": {
+                    "channel": 19,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 175,
+                "position": {
+                    "x": -6.346826722329881,
+                    "y": 4.870091432069764
+                },
+                "serial_number": 748,
+                "signal": {
+                    "channel": 19,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 1,
+                    "module": 1250,
+                    "slot": 6
+                },
+                "high_voltage": {
+                    "channel": 23,
+                    "connector": 6,
+                    "feedthrough": 1,
+                    "return": 6
+                },
+                "pmt_position": 176,
+                "position": {
+                    "x": 1.0442095377604126,
+                    "y": 7.931558890990483
+                },
+                "serial_number": 106,
+                "signal": {
+                    "channel": 23,
+                    "connector": 6,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 1,
+                    "module": 1253,
+                    "slot": 10
+                },
+                "high_voltage": {
+                    "channel": 5,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 177,
+                "position": {
+                    "x": 8.435245797850705,
+                    "y": 10.9930263499112
+                },
+                "serial_number": 117,
+                "signal": {
+                    "channel": 5,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 1,
+                    "module": 1253,
+                    "slot": 10
+                },
+                "high_voltage": {
+                    "channel": 6,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 178,
+                "position": {
+                    "x": 15.826282057941,
+                    "y": 14.05449380883192
+                },
+                "serial_number": 769,
+                "signal": {
+                    "channel": 6,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 1,
+                    "module": 1216,
+                    "slot": 9
+                },
+                "high_voltage": {
+                    "channel": 7,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 179,
+                "position": {
+                    "x": 23.217318318031293,
+                    "y": 17.11596126775264
+                },
+                "serial_number": 167,
+                "signal": {
+                    "channel": 7,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 1,
+                    "module": 1253,
+                    "slot": 10
+                },
+                "high_voltage": {
+                    "channel": 8,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 180,
+                "position": {
+                    "x": 30.608354578121585,
+                    "y": 20.177428726673355
+                },
+                "serial_number": 844,
+                "signal": {
+                    "channel": 8,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 1,
+                    "module": 1253,
+                    "slot": 10
+                },
+                "high_voltage": {
+                    "channel": 9,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 181,
+                "position": {
+                    "x": 37.99939083821188,
+                    "y": 23.238896185594072
+                },
+                "serial_number": 773,
+                "signal": {
+                    "channel": 9,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 0,
+                    "module": 117,
+                    "slot": 17
+                },
+                "high_voltage": {
+                    "channel": 20,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 182,
+                "position": {
+                    "x": -36.95518130045147,
+                    "y": -15.307337294603592
+                },
+                "serial_number": 914,
+                "signal": {
+                    "channel": 20,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 0,
+                    "module": 1234,
+                    "slot": 16
+                },
+                "high_voltage": {
+                    "channel": 21,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 183,
+                "position": {
+                    "x": -29.564145040361176,
+                    "y": -12.245869835682873
+                },
+                "serial_number": 591,
+                "signal": {
+                    "channel": 21,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 0,
+                    "module": 110,
+                    "slot": 15
+                },
+                "high_voltage": {
+                    "channel": 0,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 184,
+                "position": {
+                    "x": -22.17310878027088,
+                    "y": -9.184402376762154
+                },
+                "serial_number": 158,
+                "signal": {
+                    "channel": 0,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 0,
+                    "module": 1243,
+                    "slot": 13
+                },
+                "high_voltage": {
+                    "channel": 1,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 185,
+                "position": {
+                    "x": -14.782072520180588,
+                    "y": -6.1229349178414365
+                },
+                "serial_number": 803,
+                "signal": {
+                    "channel": 1,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 0,
+                    "module": 1233,
+                    "slot": 14
+                },
+                "high_voltage": {
+                    "channel": 2,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 186,
+                "position": {
+                    "x": -7.391036260090294,
+                    "y": -3.0614674589207183
+                },
+                "serial_number": 802,
+                "signal": {
+                    "channel": 2,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 0,
+                    "module": 117,
+                    "slot": 17
+                },
+                "high_voltage": {
+                    "channel": 22,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 187,
+                "position": {
+                    "x": 0.0,
+                    "y": 0.0
+                },
+                "serial_number": 799,
+                "signal": {
+                    "channel": 22,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 1,
+                    "module": 1216,
+                    "slot": 9
+                },
+                "high_voltage": {
+                    "channel": 10,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 188,
+                "position": {
+                    "x": 7.391036260090294,
+                    "y": 3.0614674589207183
+                },
+                "serial_number": 178,
+                "signal": {
+                    "channel": 10,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 1,
+                    "module": 1253,
+                    "slot": 10
+                },
+                "high_voltage": {
+                    "channel": 11,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 189,
+                "position": {
+                    "x": 14.782072520180588,
+                    "y": 6.1229349178414365
+                },
+                "serial_number": 129,
+                "signal": {
+                    "channel": 11,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 1,
+                    "module": 1216,
+                    "slot": 9
+                },
+                "high_voltage": {
+                    "channel": 12,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 190,
+                "position": {
+                    "x": 22.17310878027088,
+                    "y": 9.184402376762154
+                },
+                "serial_number": 103,
+                "signal": {
+                    "channel": 12,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 1,
+                    "module": 1253,
+                    "slot": 10
+                },
+                "high_voltage": {
+                    "channel": 13,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 191,
+                "position": {
+                    "x": 29.564145040361176,
+                    "y": 12.245869835682873
+                },
+                "serial_number": 172,
+                "signal": {
+                    "channel": 13,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 1,
+                    "module": 1251,
+                    "slot": 8
+                },
+                "high_voltage": {
+                    "channel": 14,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 192,
+                "position": {
+                    "x": 36.95518130045147,
+                    "y": 15.307337294603592
+                },
+                "serial_number": 846,
+                "signal": {
+                    "channel": 14,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 0,
+                    "module": 1234,
+                    "slot": 16
+                },
+                "high_voltage": {
+                    "channel": 23,
+                    "connector": 8,
+                    "feedthrough": 2,
+                    "return": 8
+                },
+                "pmt_position": 193,
+                "position": {
+                    "x": -37.99939083821188,
+                    "y": -23.238896185594072
+                },
+                "serial_number": 899,
+                "signal": {
+                    "channel": 23,
+                    "connector": 8,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 0,
+                    "module": 1243,
+                    "slot": 13
+                },
+                "high_voltage": {
+                    "channel": 3,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 194,
+                "position": {
+                    "x": -30.608354578121585,
+                    "y": -20.177428726673355
+                },
+                "serial_number": 849,
+                "signal": {
+                    "channel": 3,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 0,
+                    "module": 1233,
+                    "slot": 14
+                },
+                "high_voltage": {
+                    "channel": 4,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 195,
+                "position": {
+                    "x": -23.217318318031293,
+                    "y": -17.11596126775264
+                },
+                "serial_number": 179,
+                "signal": {
+                    "channel": 4,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 0,
+                    "module": 1246,
+                    "slot": 12
+                },
+                "high_voltage": {
+                    "channel": 5,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 196,
+                "position": {
+                    "x": -15.826282057941,
+                    "y": -14.05449380883192
+                },
+                "serial_number": 111,
+                "signal": {
+                    "channel": 5,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 0,
+                    "module": 1233,
+                    "slot": 14
+                },
+                "high_voltage": {
+                    "channel": 6,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 197,
+                "position": {
+                    "x": -8.435245797850705,
+                    "y": -10.9930263499112
+                },
+                "serial_number": 130,
+                "signal": {
+                    "channel": 6,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 0,
+                    "module": 1246,
+                    "slot": 12
+                },
+                "high_voltage": {
+                    "channel": 7,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 198,
+                "position": {
+                    "x": -1.0442095377604126,
+                    "y": -7.931558890990483
+                },
+                "serial_number": 746,
+                "signal": {
+                    "channel": 7,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 0,
+                    "module": 1237,
+                    "slot": 20
+                },
+                "high_voltage": {
+                    "channel": 0,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 199,
+                "position": {
+                    "x": 6.346826722329881,
+                    "y": -4.870091432069764
+                },
+                "serial_number": 805,
+                "signal": {
+                    "channel": 0,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 0,
+                    "module": 127,
+                    "slot": 19
+                },
+                "high_voltage": {
+                    "channel": 1,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 200,
+                "position": {
+                    "x": 13.737862982420175,
+                    "y": -1.8086239731490465
+                },
+                "serial_number": 110,
+                "signal": {
+                    "channel": 1,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 1,
+                    "module": 1251,
+                    "slot": 8
+                },
+                "high_voltage": {
+                    "channel": 15,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 201,
+                "position": {
+                    "x": 21.12889924251047,
+                    "y": 1.2528434857716721
+                },
+                "serial_number": 116,
+                "signal": {
+                    "channel": 15,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 1,
+                    "module": 1216,
+                    "slot": 9
+                },
+                "high_voltage": {
+                    "channel": 16,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 202,
+                "position": {
+                    "x": 28.519935502600763,
+                    "y": 4.314310944692391
+                },
+                "serial_number": 248,
+                "signal": {
+                    "channel": 16,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 1,
+                    "module": 1253,
+                    "slot": 10
+                },
+                "high_voltage": {
+                    "channel": 17,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 203,
+                "position": {
+                    "x": 35.910971762691055,
+                    "y": 7.375778403613108
+                },
+                "serial_number": 588,
+                "signal": {
+                    "channel": 17,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 1,
+                    "module": 1253,
+                    "slot": 10
+                },
+                "high_voltage": {
+                    "channel": 18,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 204,
+                "position": {
+                    "x": 43.30200802278135,
+                    "y": 10.437245862533826
+                },
+                "serial_number": 792,
+                "signal": {
+                    "channel": 18,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 0,
+                    "module": 110,
+                    "slot": 15
+                },
+                "high_voltage": {
+                    "channel": 8,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 205,
+                "position": {
+                    "x": -31.652564115882,
+                    "y": -28.10898761766384
+                },
+                "serial_number": 879,
+                "signal": {
+                    "channel": 8,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 0,
+                    "module": 1233,
+                    "slot": 14
+                },
+                "high_voltage": {
+                    "channel": 9,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 206,
+                "position": {
+                    "x": -24.261527855791705,
+                    "y": -25.04752015874312
+                },
+                "serial_number": 707,
+                "signal": {
+                    "channel": 9,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 0,
+                    "module": 1233,
+                    "slot": 14
+                },
+                "high_voltage": {
+                    "channel": 10,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 207,
+                "position": {
+                    "x": -16.87049159570141,
+                    "y": -21.9860526998224
+                },
+                "serial_number": 847,
+                "signal": {
+                    "channel": 10,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 0,
+                    "module": 1233,
+                    "slot": 14
+                },
+                "high_voltage": {
+                    "channel": 11,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 208,
+                "position": {
+                    "x": -9.479455335611119,
+                    "y": -18.924585240901685
+                },
+                "serial_number": 107,
+                "signal": {
+                    "channel": 11,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 0,
+                    "module": 110,
+                    "slot": 15
+                },
+                "high_voltage": {
+                    "channel": 12,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 209,
+                "position": {
+                    "x": -2.088419075520825,
+                    "y": -15.863117781980966
+                },
+                "serial_number": 112,
+                "signal": {
+                    "channel": 12,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 0,
+                    "module": 1236,
+                    "slot": 18
+                },
+                "high_voltage": {
+                    "channel": 2,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 210,
+                "position": {
+                    "x": 5.302617184569469,
+                    "y": -12.801650323060247
+                },
+                "serial_number": 840,
+                "signal": {
+                    "channel": 2,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 0,
+                    "module": 1237,
+                    "slot": 20
+                },
+                "high_voltage": {
+                    "channel": 3,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 211,
+                "position": {
+                    "x": 12.693653444659763,
+                    "y": -9.740182864139529
+                },
+                "serial_number": 807,
+                "signal": {
+                    "channel": 3,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 0,
+                    "module": 1236,
+                    "slot": 18
+                },
+                "high_voltage": {
+                    "channel": 4,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 212,
+                "position": {
+                    "x": 20.084689704750055,
+                    "y": -6.678715405218811
+                },
+                "serial_number": 774,
+                "signal": {
+                    "channel": 4,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 1,
+                    "module": 1251,
+                    "slot": 8
+                },
+                "high_voltage": {
+                    "channel": 19,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 213,
+                "position": {
+                    "x": 27.47572596484035,
+                    "y": -3.617247946298093
+                },
+                "serial_number": 169,
+                "signal": {
+                    "channel": 19,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 1,
+                    "module": 1251,
+                    "slot": 8
+                },
+                "high_voltage": {
+                    "channel": 20,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 214,
+                "position": {
+                    "x": 34.866762224930646,
+                    "y": -0.5557804873773744
+                },
+                "serial_number": 750,
+                "signal": {
+                    "channel": 20,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 1,
+                    "module": 1216,
+                    "slot": 9
+                },
+                "high_voltage": {
+                    "channel": 21,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 215,
+                "position": {
+                    "x": 42.25779848502094,
+                    "y": 2.5056869715433443
+                },
+                "serial_number": 797,
+                "signal": {
+                    "channel": 21,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 0,
+                    "crate": 0,
+                    "module": 1246,
+                    "slot": 12
+                },
+                "high_voltage": {
+                    "channel": 13,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 216,
+                "position": {
+                    "x": -25.305737393552118,
+                    "y": -32.979079049733606
+                },
+                "serial_number": 871,
+                "signal": {
+                    "channel": 13,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 0,
+                    "module": 1246,
+                    "slot": 12
+                },
+                "high_voltage": {
+                    "channel": 14,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 217,
+                "position": {
+                    "x": -17.914701133461826,
+                    "y": -29.91761159081289
+                },
+                "serial_number": 456,
+                "signal": {
+                    "channel": 14,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 0,
+                    "module": 1243,
+                    "slot": 13
+                },
+                "high_voltage": {
+                    "channel": 15,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 218,
+                "position": {
+                    "x": -10.523664873371533,
+                    "y": -26.85614413189217
+                },
+                "serial_number": 776,
+                "signal": {
+                    "channel": 15,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 0,
+                    "module": 110,
+                    "slot": 15
+                },
+                "high_voltage": {
+                    "channel": 16,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 219,
+                "position": {
+                    "x": -3.132628613281237,
+                    "y": -23.79467667297145
+                },
+                "serial_number": 864,
+                "signal": {
+                    "channel": 16,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 0,
+                    "module": 1237,
+                    "slot": 20
+                },
+                "high_voltage": {
+                    "channel": 5,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 220,
+                "position": {
+                    "x": 4.258407646809056,
+                    "y": -20.73320921405073
+                },
+                "serial_number": 136,
+                "signal": {
+                    "channel": 5,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 0,
+                    "module": 1236,
+                    "slot": 18
+                },
+                "high_voltage": {
+                    "channel": 6,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 221,
+                "position": {
+                    "x": 11.64944390689935,
+                    "y": -17.671741755130014
+                },
+                "serial_number": 788,
+                "signal": {
+                    "channel": 6,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 0,
+                    "module": 127,
+                    "slot": 19
+                },
+                "high_voltage": {
+                    "channel": 7,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 222,
+                "position": {
+                    "x": 19.040480166989642,
+                    "y": -14.610274296209296
+                },
+                "serial_number": 115,
+                "signal": {
+                    "channel": 7,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 0,
+                    "module": 1237,
+                    "slot": 20
+                },
+                "high_voltage": {
+                    "channel": 8,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 223,
+                "position": {
+                    "x": 26.431516427079938,
+                    "y": -11.548806837288577
+                },
+                "serial_number": 800,
+                "signal": {
+                    "channel": 8,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 1,
+                    "module": 1251,
+                    "slot": 8
+                },
+                "high_voltage": {
+                    "channel": 22,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 224,
+                "position": {
+                    "x": 33.82255268717023,
+                    "y": -8.487339378367858
+                },
+                "serial_number": 842,
+                "signal": {
+                    "channel": 22,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 1,
+                    "module": 1216,
+                    "slot": 9
+                },
+                "high_voltage": {
+                    "channel": 23,
+                    "connector": 7,
+                    "feedthrough": 1,
+                    "return": 7
+                },
+                "pmt_position": 225,
+                "position": {
+                    "x": 41.213588947260526,
+                    "y": -5.425871919447141
+                },
+                "serial_number": 798,
+                "signal": {
+                    "channel": 23,
+                    "connector": 7,
+                    "feedthrough": 2
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 0,
+                    "module": 1243,
+                    "slot": 13
+                },
+                "high_voltage": {
+                    "channel": 17,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 226,
+                "position": {
+                    "x": -18.958910671222238,
+                    "y": -37.84917048180337
+                },
+                "serial_number": 868,
+                "signal": {
+                    "channel": 17,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 0,
+                    "module": 110,
+                    "slot": 15
+                },
+                "high_voltage": {
+                    "channel": 18,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 227,
+                "position": {
+                    "x": -11.567874411131942,
+                    "y": -34.78770302288265
+                },
+                "serial_number": 126,
+                "signal": {
+                    "channel": 18,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 0,
+                    "module": 1246,
+                    "slot": 12
+                },
+                "high_voltage": {
+                    "channel": 19,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 228,
+                "position": {
+                    "x": -4.17683815104165,
+                    "y": -31.726235563961932
+                },
+                "serial_number": 174,
+                "signal": {
+                    "channel": 19,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 0,
+                    "module": 1236,
+                    "slot": 18
+                },
+                "high_voltage": {
+                    "channel": 9,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 229,
+                "position": {
+                    "x": 3.2141981090486436,
+                    "y": -28.66476810504121
+                },
+                "serial_number": 592,
+                "signal": {
+                    "channel": 9,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 0,
+                    "module": 1237,
+                    "slot": 20
+                },
+                "high_voltage": {
+                    "channel": 10,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 230,
+                "position": {
+                    "x": 10.605234369138937,
+                    "y": -25.603300646120495
+                },
+                "serial_number": 177,
+                "signal": {
+                    "channel": 10,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 0,
+                    "module": 1236,
+                    "slot": 18
+                },
+                "high_voltage": {
+                    "channel": 11,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 231,
+                "position": {
+                    "x": 17.99627062922923,
+                    "y": -22.541833187199778
+                },
+                "serial_number": 105,
+                "signal": {
+                    "channel": 11,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 0,
+                    "module": 1237,
+                    "slot": 20
+                },
+                "high_voltage": {
+                    "channel": 12,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 232,
+                "position": {
+                    "x": 25.387306889319525,
+                    "y": -19.480365728279057
+                },
+                "serial_number": 246,
+                "signal": {
+                    "channel": 12,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 0,
+                    "module": 127,
+                    "slot": 19
+                },
+                "high_voltage": {
+                    "channel": 13,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 233,
+                "position": {
+                    "x": 32.77834314940982,
+                    "y": -16.41889826935834
+                },
+                "serial_number": 168,
+                "signal": {
+                    "channel": 13,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 0,
+                    "module": 1236,
+                    "slot": 18
+                },
+                "high_voltage": {
+                    "channel": 14,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 234,
+                "position": {
+                    "x": 40.16937940950011,
+                    "y": -13.357430810437622
+                },
+                "serial_number": 810,
+                "signal": {
+                    "channel": 14,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 0,
+                    "module": 110,
+                    "slot": 15
+                },
+                "high_voltage": {
+                    "channel": 20,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 235,
+                "position": {
+                    "x": -12.612083948892357,
+                    "y": -42.71926191387313
+                },
+                "serial_number": 853,
+                "signal": {
+                    "channel": 20,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 0,
+                    "module": 1243,
+                    "slot": 13
+                },
+                "high_voltage": {
+                    "channel": 21,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 236,
+                "position": {
+                    "x": -5.221047688802065,
+                    "y": -39.65779445495241
+                },
+                "serial_number": 927,
+                "signal": {
+                    "channel": 21,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 0,
+                    "module": 1243,
+                    "slot": 13
+                },
+                "high_voltage": {
+                    "channel": 22,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 237,
+                "position": {
+                    "x": 2.169988571288231,
+                    "y": -36.59632699603169
+                },
+                "serial_number": 224,
+                "signal": {
+                    "channel": 22,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 7,
+                    "crate": 0,
+                    "module": 127,
+                    "slot": 19
+                },
+                "high_voltage": {
+                    "channel": 15,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 238,
+                "position": {
+                    "x": 9.561024831378525,
+                    "y": -33.534859537110975
+                },
+                "serial_number": 589,
+                "signal": {
+                    "channel": 15,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 0,
+                    "module": 1237,
+                    "slot": 20
+                },
+                "high_voltage": {
+                    "channel": 16,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 239,
+                "position": {
+                    "x": 16.952061091468817,
+                    "y": -30.47339207819026
+                },
+                "serial_number": 560,
+                "signal": {
+                    "channel": 16,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 0,
+                    "module": 1236,
+                    "slot": 18
+                },
+                "high_voltage": {
+                    "channel": 17,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 240,
+                "position": {
+                    "x": 24.34309735155911,
+                    "y": -27.41192461926954
+                },
+                "serial_number": 217,
+                "signal": {
+                    "channel": 17,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 1,
+                    "crate": 0,
+                    "module": 127,
+                    "slot": 19
+                },
+                "high_voltage": {
+                    "channel": 18,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 241,
+                "position": {
+                    "x": 31.734133611649405,
+                    "y": -24.35045716034882
+                },
+                "serial_number": 212,
+                "signal": {
+                    "channel": 18,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 2,
+                    "crate": 0,
+                    "module": 127,
+                    "slot": 19
+                },
+                "high_voltage": {
+                    "channel": 19,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 242,
+                "position": {
+                    "x": 39.1251698717397,
+                    "y": -21.2889897014281
+                },
+                "serial_number": 822,
+                "signal": {
+                    "channel": 19,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 0,
+                    "module": 110,
+                    "slot": 15
+                },
+                "high_voltage": {
+                    "channel": 23,
+                    "connector": 10,
+                    "feedthrough": 2,
+                    "return": 10
+                },
+                "pmt_position": 243,
+                "position": {
+                    "x": 1.1257790335278184,
+                    "y": -44.52788588702218
+                },
+                "serial_number": 852,
+                "signal": {
+                    "channel": 23,
+                    "connector": 10,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 3,
+                    "crate": 0,
+                    "module": 127,
+                    "slot": 19
+                },
+                "high_voltage": {
+                    "channel": 20,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 244,
+                "position": {
+                    "x": 8.516815293618112,
+                    "y": -41.46641842810146
+                },
+                "serial_number": 845,
+                "signal": {
+                    "channel": 20,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 0,
+                    "module": 1237,
+                    "slot": 20
+                },
+                "high_voltage": {
+                    "channel": 21,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 245,
+                "position": {
+                    "x": 15.907851553708406,
+                    "y": -38.404950969180746
+                },
+                "serial_number": 841,
+                "signal": {
+                    "channel": 21,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 0,
+                    "module": 1236,
+                    "slot": 18
+                },
+                "high_voltage": {
+                    "channel": 22,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 246,
+                "position": {
+                    "x": 23.2988878137987,
+                    "y": -35.34348351026003
+                },
+                "serial_number": 834,
+                "signal": {
+                    "channel": 22,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "bottom",
+                "digitizer": {
+                    "channel": 5,
+                    "crate": 0,
+                    "module": 127,
+                    "slot": 19
+                },
+                "high_voltage": {
+                    "channel": 23,
+                    "connector": 9,
+                    "feedthrough": 2,
+                    "return": 9
+                },
+                "pmt_position": 247,
+                "position": {
+                    "x": 30.689924073888996,
+                    "y": -32.28201605133931
+                },
+                "serial_number": 823,
+                "signal": {
+                    "channel": 23,
+                    "connector": 9,
+                    "feedthrough": 3
+                }
+            },
+            {
+                "array": "diagnostic",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 0,
+                    "module": 154,
+                    "slot": 7
+                },
+                "high_voltage": {
+                    "channel": 15,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 248,
+                "position": {
+                    "x": 0.0,
+                    "y": 0.0
+                },
+                "serial_number": -1,
+                "signal": {
+                    "channel": 15,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "diagnostic",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 0,
+                    "module": 1239,
+                    "slot": 6
+                },
+                "high_voltage": {
+                    "channel": 16,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 249,
+                "position": {
+                    "x": 0.0,
+                    "y": 0.0
+                },
+                "serial_number": -1,
+                "signal": {
+                    "channel": 16,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "diagnostic",
+                "digitizer": {
+                    "channel": 4,
+                    "crate": 0,
+                    "module": 153,
+                    "slot": 5
+                },
+                "high_voltage": {
+                    "channel": 17,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 250,
+                "position": {
+                    "x": 0.0,
+                    "y": 0.0
+                },
+                "serial_number": -1,
+                "signal": {
+                    "channel": 17,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "diagnostic",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 0,
+                    "module": 154,
+                    "slot": 7
+                },
+                "high_voltage": {
+                    "channel": 18,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 251,
+                "position": {
+                    "x": 0.0,
+                    "y": 0.0
+                },
+                "serial_number": -1,
+                "signal": {
+                    "channel": 18,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "diagnostic",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 0,
+                    "module": 1239,
+                    "slot": 6
+                },
+                "high_voltage": {
+                    "channel": 19,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 252,
+                "position": {
+                    "x": 0.0,
+                    "y": 0.0
+                },
+                "serial_number": -1,
+                "signal": {
+                    "channel": 19,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            },
+            {
+                "array": "diagnostic",
+                "digitizer": {
+                    "channel": 6,
+                    "crate": 0,
+                    "module": 153,
+                    "slot": 5
+                },
+                "high_voltage": {
+                    "channel": 20,
+                    "connector": 5,
+                    "feedthrough": 1,
+                    "return": 5
+                },
+                "pmt_position": 253,
+                "position": {
+                    "x": 0.0,
+                    "y": 0.0
+                },
+                "serial_number": -1,
+                "signal": {
+                    "channel": 20,
+                    "connector": 5,
+                    "feedthrough": 1
+                }
+            }
+        ]

--- a/pax/config/XENON1T.ini
+++ b/pax/config/XENON1T.ini
@@ -863,6 +863,13 @@ relative_gain_error = 0.03                         # PLACEHOLDER
 # "Static" PMT info (stuff that doesn't need to be calibrated and won't change unless somebody makes a hardware change)
 pmts  = [
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 5,
+                    "serial": 29651,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 3,
@@ -889,6 +896,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 11,
+                    "serial": 8617,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 2,
@@ -915,6 +929,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 12,
+                    "serial": 8617,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -941,6 +962,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 13,
+                    "serial": 8617,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 3,
@@ -967,6 +995,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 14,
+                    "serial": 8617,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -993,6 +1028,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 15,
+                    "serial": 8617,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -1019,6 +1061,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 0,
+                    "serial": 24678,
+                    "slot": 7
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 0,
@@ -1045,6 +1094,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 0,
+                    "serial": 29652,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 1,
@@ -1071,6 +1127,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 1,
+                    "serial": 29652,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 1,
@@ -1097,6 +1160,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 2,
+                    "serial": 29652,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 1,
@@ -1123,6 +1193,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 3,
+                    "serial": 29652,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 0,
@@ -1149,6 +1226,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 4,
+                    "serial": 29652,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 2,
@@ -1175,6 +1259,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 5,
+                    "serial": 29652,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 4,
@@ -1201,6 +1292,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 8,
+                    "serial": 1004,
+                    "slot": 9
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -1227,6 +1325,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 9,
+                    "serial": 1004,
+                    "slot": 9
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -1253,6 +1358,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 10,
+                    "serial": 1004,
+                    "slot": 9
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -1279,6 +1391,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 11,
+                    "serial": 1004,
+                    "slot": 9
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 6,
@@ -1305,6 +1424,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 12,
+                    "serial": 1004,
+                    "slot": 9
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 6,
@@ -1331,6 +1457,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 13,
+                    "serial": 1004,
+                    "slot": 9
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 6,
@@ -1357,6 +1490,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 11,
+                    "serial": 29648,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 7,
@@ -1383,6 +1523,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 12,
+                    "serial": 29648,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 7,
@@ -1409,6 +1556,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 13,
+                    "serial": 29648,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 7,
@@ -1435,6 +1589,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 14,
+                    "serial": 29648,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 7,
@@ -1461,6 +1622,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 15,
+                    "serial": 29648,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 7,
@@ -1487,6 +1655,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 0,
+                    "serial": 8617,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 0,
@@ -1513,6 +1688,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 8,
+                    "serial": 29650,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 0,
@@ -1539,6 +1721,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 9,
+                    "serial": 29650,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 1,
@@ -1565,6 +1754,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 10,
+                    "serial": 29650,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 1,
@@ -1591,6 +1787,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 11,
+                    "serial": 29650,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 2,
@@ -1617,6 +1820,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 12,
+                    "serial": 29650,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 4,
@@ -1643,6 +1853,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 13,
+                    "serial": 29650,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 4,
@@ -1669,6 +1886,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 0,
+                    "serial": 29651,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 0,
@@ -1695,6 +1919,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 1,
+                    "serial": 29651,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 0,
@@ -1721,6 +1952,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 2,
+                    "serial": 29651,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 2,
@@ -1747,6 +1985,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 3,
+                    "serial": 29651,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 1,
@@ -1773,6 +2018,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 4,
+                    "serial": 29651,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 7,
@@ -1799,6 +2051,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 10,
+                    "serial": 29651,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -1825,6 +2084,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 11,
+                    "serial": 29651,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 6,
@@ -1851,6 +2117,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 1,
+                    "serial": 24678,
+                    "slot": 7
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 0,
@@ -1877,6 +2150,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 2,
+                    "serial": 24678,
+                    "slot": 7
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 0,
@@ -1903,6 +2183,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 3,
+                    "serial": 24678,
+                    "slot": 7
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 1,
@@ -1929,6 +2216,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 4,
+                    "serial": 24678,
+                    "slot": 7
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 1,
@@ -1955,6 +2249,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 6,
+                    "serial": 29652,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 3,
@@ -1981,6 +2282,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 7,
+                    "serial": 29652,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 4,
@@ -2007,6 +2315,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 8,
+                    "serial": 29652,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -2033,6 +2348,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 9,
+                    "serial": 29652,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -2059,6 +2381,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 10,
+                    "serial": 29652,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 6,
@@ -2085,6 +2414,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 14,
+                    "serial": 1004,
+                    "slot": 9
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 7,
@@ -2111,6 +2447,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 15,
+                    "serial": 1004,
+                    "slot": 9
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 7,
@@ -2137,6 +2480,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 8,
+                    "serial": 13265,
+                    "slot": 8
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 4,
@@ -2163,6 +2513,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 9,
+                    "serial": 13265,
+                    "slot": 8
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -2189,6 +2546,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 10,
+                    "serial": 13265,
+                    "slot": 8
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -2215,6 +2579,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 11,
+                    "serial": 13265,
+                    "slot": 8
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 6,
@@ -2241,6 +2612,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 1,
+                    "serial": 8617,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 1,
@@ -2267,6 +2645,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 2,
+                    "serial": 8617,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 2,
@@ -2293,6 +2678,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 3,
+                    "serial": 8617,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 4,
@@ -2319,6 +2711,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 4,
+                    "serial": 8617,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 3,
@@ -2345,6 +2744,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 14,
+                    "serial": 29650,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 6,
@@ -2371,6 +2777,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 15,
+                    "serial": 29650,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -2397,6 +2810,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 8,
+                    "serial": 29647,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 0,
@@ -2423,6 +2843,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 9,
+                    "serial": 29647,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 1,
@@ -2449,6 +2876,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 10,
+                    "serial": 29647,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 2,
@@ -2475,6 +2909,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 6,
+                    "serial": 29651,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -2501,6 +2942,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 7,
+                    "serial": 29651,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 4,
@@ -2527,6 +2975,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 8,
+                    "serial": 29651,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 7,
@@ -2553,6 +3008,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 9,
+                    "serial": 29651,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 6,
@@ -2579,6 +3041,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 2,
+                    "serial": 29648,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 3,
@@ -2605,6 +3074,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 3,
+                    "serial": 29648,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 2,
@@ -2631,6 +3107,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 5,
+                    "serial": 24678,
+                    "slot": 7
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 1,
@@ -2657,6 +3140,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 6,
+                    "serial": 24678,
+                    "slot": 7
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 2,
@@ -2683,6 +3173,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 11,
+                    "serial": 29652,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 6,
@@ -2709,6 +3206,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 12,
+                    "serial": 29652,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 6,
@@ -2735,6 +3239,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 13,
+                    "serial": 29652,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 7,
@@ -2761,6 +3272,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 14,
+                    "serial": 29652,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 7,
@@ -2787,6 +3305,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 15,
+                    "serial": 29652,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 7,
@@ -2813,6 +3338,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 12,
+                    "serial": 13265,
+                    "slot": 8
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 6,
@@ -2839,6 +3371,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 13,
+                    "serial": 13265,
+                    "slot": 8
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 7,
@@ -2865,6 +3404,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 14,
+                    "serial": 1002,
+                    "slot": 2
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 6,
@@ -2891,6 +3437,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 15,
+                    "serial": 1002,
+                    "slot": 2
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 0,
@@ -2917,6 +3470,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 11,
+                    "serial": 24681,
+                    "slot": 3
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 2,
@@ -2943,6 +3503,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 5,
+                    "serial": 8617,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 3,
@@ -2969,6 +3536,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 6,
+                    "serial": 8617,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -2995,6 +3569,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 11,
+                    "serial": 29647,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 2,
@@ -3021,6 +3602,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 12,
+                    "serial": 29647,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -3047,6 +3635,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 13,
+                    "serial": 29647,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -3073,6 +3668,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 14,
+                    "serial": 29647,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 6,
@@ -3099,6 +3701,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 15,
+                    "serial": 29647,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 7,
@@ -3125,6 +3734,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 12,
+                    "serial": 29651,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 7,
@@ -3151,6 +3767,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 0,
+                    "serial": 29648,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -3177,6 +3800,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 1,
+                    "serial": 29648,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 1,
@@ -3203,6 +3833,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 6,
+                    "serial": 29648,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 6,
@@ -3229,6 +3866,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 7,
+                    "serial": 29648,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 7,
@@ -3255,6 +3899,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 7,
+                    "serial": 24678,
+                    "slot": 7
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 2,
@@ -3281,6 +3932,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 0,
+                    "serial": 29650,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 0,
@@ -3307,6 +3965,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 1,
+                    "serial": 29650,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 0,
@@ -3333,6 +3998,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 2,
+                    "serial": 29650,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 2,
@@ -3359,6 +4031,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 3,
+                    "serial": 29650,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 2,
@@ -3385,6 +4064,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 12,
+                    "serial": 24681,
+                    "slot": 3
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -3411,6 +4097,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 13,
+                    "serial": 24681,
+                    "slot": 3
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 3,
@@ -3437,6 +4130,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 14,
+                    "serial": 24681,
+                    "slot": 3
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -3463,6 +4163,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 15,
+                    "serial": 24681,
+                    "slot": 3
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 0,
@@ -3489,6 +4196,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 7,
+                    "serial": 8617,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 4,
@@ -3515,6 +4229,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 8,
+                    "serial": 29653,
+                    "slot": 7
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 0,
@@ -3541,6 +4262,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 9,
+                    "serial": 29653,
+                    "slot": 7
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 3,
@@ -3567,6 +4295,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 10,
+                    "serial": 29653,
+                    "slot": 7
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 3,
@@ -3593,6 +4328,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 11,
+                    "serial": 29653,
+                    "slot": 7
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 3,
@@ -3619,6 +4361,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 4,
+                    "serial": 29648,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 2,
@@ -3645,6 +4394,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 5,
+                    "serial": 29648,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 4,
@@ -3671,6 +4427,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 9,
+                    "serial": 29648,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 0,
@@ -3697,6 +4460,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 8,
+                    "serial": 24678,
+                    "slot": 7
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 3,
@@ -3723,6 +4493,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 4,
+                    "serial": 29650,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 3,
@@ -3749,6 +4526,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 5,
+                    "serial": 29650,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 3,
@@ -3775,6 +4559,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 6,
+                    "serial": 29650,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 4,
@@ -3801,6 +4592,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 13,
+                    "serial": 29651,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 6,
@@ -3827,6 +4625,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 14,
+                    "serial": 29651,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 3,
@@ -3853,6 +4658,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 8,
+                    "serial": 8617,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 6,
@@ -3879,6 +4691,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 12,
+                    "serial": 29653,
+                    "slot": 7
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 4,
@@ -3905,6 +4724,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 13,
+                    "serial": 29653,
+                    "slot": 7
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 6,
@@ -3931,6 +4757,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 14,
+                    "serial": 29653,
+                    "slot": 7
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 7,
@@ -3957,6 +4790,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 8,
+                    "serial": 29648,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 6,
@@ -3983,6 +4823,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 10,
+                    "serial": 29648,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 1,
@@ -4009,6 +4856,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 9,
+                    "serial": 24678,
+                    "slot": 7
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 3,
@@ -4035,6 +4889,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 7,
+                    "serial": 29650,
+                    "slot": 5
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -4061,6 +4922,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 15,
+                    "serial": 29651,
+                    "slot": 4
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 7,
@@ -4087,6 +4955,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 9,
+                    "serial": 8617,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 5,
@@ -4113,6 +4988,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": -1,
+                    "plug": 15,
+                    "serial": 29653,
+                    "slot": 7
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 7,
@@ -4139,6 +5021,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 10,
+                    "serial": 8617,
+                    "slot": 6
+                },
                 "array": "top",
                 "digitizer": {
                     "channel": 6,
@@ -4165,6 +5054,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 16,
+                    "plug": 0,
+                    "serial": 13266,
+                    "slot": 10
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 2,
@@ -4191,6 +5087,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 17,
+                    "plug": 1,
+                    "serial": 13266,
+                    "slot": 10
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 1,
@@ -4217,6 +5120,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 18,
+                    "plug": 2,
+                    "serial": 13266,
+                    "slot": 10
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 2,
@@ -4243,6 +5153,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 19,
+                    "plug": 3,
+                    "serial": 13266,
+                    "slot": 10
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 3,
@@ -4269,6 +5186,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 20,
+                    "plug": 4,
+                    "serial": 13266,
+                    "slot": 10
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 3,
@@ -4295,6 +5219,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 8,
+                    "plug": 8,
+                    "serial": 29649,
+                    "slot": 11
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 0,
@@ -4321,6 +5252,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 9,
+                    "plug": 9,
+                    "serial": 29649,
+                    "slot": 11
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 0,
@@ -4347,6 +5285,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 21,
+                    "plug": 5,
+                    "serial": 13266,
+                    "slot": 10
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 3,
@@ -4373,6 +5318,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 22,
+                    "plug": 6,
+                    "serial": 13266,
+                    "slot": 10
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 4,
@@ -4399,6 +5351,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 23,
+                    "plug": 7,
+                    "serial": 13266,
+                    "slot": 10
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 4,
@@ -4425,6 +5384,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 0,
+                    "plug": 0,
+                    "serial": 29649,
+                    "slot": 11
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 0,
@@ -4451,6 +5417,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 1,
+                    "plug": 1,
+                    "serial": 29649,
+                    "slot": 11
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 0,
@@ -4477,6 +5450,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 2,
+                    "plug": 2,
+                    "serial": 29649,
+                    "slot": 11
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 1,
@@ -4503,6 +5483,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 10,
+                    "plug": 10,
+                    "serial": 29649,
+                    "slot": 11
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 1,
@@ -4529,6 +5516,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 11,
+                    "plug": 11,
+                    "serial": 29649,
+                    "slot": 11
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 3,
@@ -4555,6 +5549,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 12,
+                    "plug": 12,
+                    "serial": 29649,
+                    "slot": 11
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 5,
@@ -4581,6 +5582,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 3,
+                    "plug": 3,
+                    "serial": 29649,
+                    "slot": 11
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 0,
@@ -4607,6 +5615,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 4,
+                    "plug": 4,
+                    "serial": 29649,
+                    "slot": 11
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 1,
@@ -4633,6 +5648,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 5,
+                    "plug": 5,
+                    "serial": 29649,
+                    "slot": 11
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 1,
@@ -4659,6 +5681,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 6,
+                    "plug": 6,
+                    "serial": 29649,
+                    "slot": 11
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 2,
@@ -4685,6 +5714,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 7,
+                    "plug": 7,
+                    "serial": 29649,
+                    "slot": 11
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 2,
@@ -4711,6 +5747,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 96,
+                    "plug": 0,
+                    "serial": 1002,
+                    "slot": 2
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 1,
@@ -4737,6 +5780,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 13,
+                    "plug": 13,
+                    "serial": 29649,
+                    "slot": 11
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 6,
@@ -4763,6 +5813,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 14,
+                    "plug": 14,
+                    "serial": 29649,
+                    "slot": 11
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 6,
@@ -4789,6 +5846,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 15,
+                    "plug": 15,
+                    "serial": 29649,
+                    "slot": 11
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 7,
@@ -4815,6 +5879,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 24,
+                    "plug": 8,
+                    "serial": 13266,
+                    "slot": 10
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 1,
@@ -4841,6 +5912,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 32,
+                    "plug": 0,
+                    "serial": 1004,
+                    "slot": 9
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 0,
@@ -4867,6 +5945,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 33,
+                    "plug": 1,
+                    "serial": 1004,
+                    "slot": 9
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 0,
@@ -4893,6 +5978,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 34,
+                    "plug": 2,
+                    "serial": 1004,
+                    "slot": 9
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 1,
@@ -4919,6 +6011,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 35,
+                    "plug": 3,
+                    "serial": 1004,
+                    "slot": 9
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 2,
@@ -4945,6 +6044,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 40,
+                    "plug": 0,
+                    "serial": 13265,
+                    "slot": 8
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 0,
@@ -4971,6 +6077,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 41,
+                    "plug": 1,
+                    "serial": 13265,
+                    "slot": 8
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 1,
@@ -4997,6 +6110,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 25,
+                    "plug": 9,
+                    "serial": 13266,
+                    "slot": 10
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 3,
@@ -5023,6 +6143,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 26,
+                    "plug": 10,
+                    "serial": 13266,
+                    "slot": 10
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 2,
@@ -5049,6 +6176,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 27,
+                    "plug": 11,
+                    "serial": 13266,
+                    "slot": 10
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 2,
@@ -5075,6 +6209,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 28,
+                    "plug": 12,
+                    "serial": 13266,
+                    "slot": 10
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 5,
@@ -5101,6 +6242,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 29,
+                    "plug": 13,
+                    "serial": 13266,
+                    "slot": 10
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 4,
@@ -5127,6 +6275,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 36,
+                    "plug": 4,
+                    "serial": 1004,
+                    "slot": 9
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 3,
@@ -5153,6 +6308,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 37,
+                    "plug": 5,
+                    "serial": 1004,
+                    "slot": 9
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 4,
@@ -5179,6 +6341,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 38,
+                    "plug": 6,
+                    "serial": 1004,
+                    "slot": 9
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 3,
@@ -5205,6 +6374,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 42,
+                    "plug": 2,
+                    "serial": 13265,
+                    "slot": 8
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 2,
@@ -5231,6 +6407,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 43,
+                    "plug": 3,
+                    "serial": 13265,
+                    "slot": 8
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 3,
@@ -5257,6 +6440,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 44,
+                    "plug": 4,
+                    "serial": 13265,
+                    "slot": 8
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 2,
@@ -5283,6 +6473,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 30,
+                    "plug": 14,
+                    "serial": 13266,
+                    "slot": 10
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 7,
@@ -5309,6 +6506,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 31,
+                    "plug": 15,
+                    "serial": 13266,
+                    "slot": 10
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 4,
@@ -5335,6 +6539,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 88,
+                    "plug": 8,
+                    "serial": 24672,
+                    "slot": 1
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 0,
@@ -5361,6 +6572,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 89,
+                    "plug": 9,
+                    "serial": 24672,
+                    "slot": 1
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 1,
@@ -5387,6 +6605,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 90,
+                    "plug": 10,
+                    "serial": 24672,
+                    "slot": 1
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 0,
@@ -5413,6 +6638,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 91,
+                    "plug": 11,
+                    "serial": 24672,
+                    "slot": 1
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 1,
@@ -5439,6 +6671,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 39,
+                    "plug": 7,
+                    "serial": 1004,
+                    "slot": 9
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 4,
@@ -5465,6 +6704,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 45,
+                    "plug": 5,
+                    "serial": 13265,
+                    "slot": 8
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 5,
@@ -5491,6 +6737,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 46,
+                    "plug": 6,
+                    "serial": 13265,
+                    "slot": 8
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 7,
@@ -5517,6 +6770,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 47,
+                    "plug": 7,
+                    "serial": 13265,
+                    "slot": 8
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 7,
@@ -5543,6 +6803,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 48,
+                    "plug": 0,
+                    "serial": 29653,
+                    "slot": 7
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 2,
@@ -5569,6 +6836,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 49,
+                    "plug": 1,
+                    "serial": 29653,
+                    "slot": 7
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 3,
@@ -5595,6 +6869,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 92,
+                    "plug": 12,
+                    "serial": 24672,
+                    "slot": 1
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 2,
@@ -5621,6 +6902,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 93,
+                    "plug": 13,
+                    "serial": 24672,
+                    "slot": 1
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 4,
@@ -5647,6 +6935,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 97,
+                    "plug": 1,
+                    "serial": 1002,
+                    "slot": 2
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 1,
@@ -5673,6 +6968,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 98,
+                    "plug": 2,
+                    "serial": 1002,
+                    "slot": 2
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 0,
@@ -5699,6 +7001,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 99,
+                    "plug": 3,
+                    "serial": 1002,
+                    "slot": 2
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 2,
@@ -5725,6 +7034,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 94,
+                    "plug": 14,
+                    "serial": 24672,
+                    "slot": 1
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 4,
@@ -5751,6 +7067,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 50,
+                    "plug": 2,
+                    "serial": 29653,
+                    "slot": 7
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 3,
@@ -5777,6 +7100,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 51,
+                    "plug": 3,
+                    "serial": 29653,
+                    "slot": 7
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 4,
@@ -5803,6 +7133,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 52,
+                    "plug": 4,
+                    "serial": 29653,
+                    "slot": 7
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 5,
@@ -5829,6 +7166,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 53,
+                    "plug": 5,
+                    "serial": 29653,
+                    "slot": 7
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 6,
@@ -5855,6 +7199,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 54,
+                    "plug": 6,
+                    "serial": 29653,
+                    "slot": 7
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 6,
@@ -5881,6 +7232,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 95,
+                    "plug": 15,
+                    "serial": 24672,
+                    "slot": 1
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 7,
@@ -5907,6 +7265,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 100,
+                    "plug": 4,
+                    "serial": 1002,
+                    "slot": 2
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 3,
@@ -5933,6 +7298,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 101,
+                    "plug": 5,
+                    "serial": 1002,
+                    "slot": 2
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 3,
@@ -5959,6 +7331,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 102,
+                    "plug": 6,
+                    "serial": 1002,
+                    "slot": 2
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 3,
@@ -5985,6 +7364,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 103,
+                    "plug": 7,
+                    "serial": 1002,
+                    "slot": 2
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 4,
@@ -6011,6 +7397,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 104,
+                    "plug": 8,
+                    "serial": 1002,
+                    "slot": 2
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 4,
@@ -6037,6 +7430,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 64,
+                    "plug": 0,
+                    "serial": 24096,
+                    "slot": 0
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 0,
@@ -6063,6 +7463,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 65,
+                    "plug": 1,
+                    "serial": 24096,
+                    "slot": 0
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 0,
@@ -6089,6 +7496,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 55,
+                    "plug": 7,
+                    "serial": 29653,
+                    "slot": 7
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 7,
@@ -6115,6 +7529,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 56,
+                    "plug": 0,
+                    "serial": 29647,
+                    "slot": 6
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 0,
@@ -6141,6 +7562,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 57,
+                    "plug": 1,
+                    "serial": 29647,
+                    "slot": 6
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 1,
@@ -6167,6 +7595,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 58,
+                    "plug": 2,
+                    "serial": 29647,
+                    "slot": 6
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 0,
@@ -6193,6 +7628,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 105,
+                    "plug": 9,
+                    "serial": 1002,
+                    "slot": 2
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 5,
@@ -6219,6 +7661,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 106,
+                    "plug": 10,
+                    "serial": 1002,
+                    "slot": 2
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 7,
@@ -6245,6 +7694,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 107,
+                    "plug": 11,
+                    "serial": 1002,
+                    "slot": 2
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 5,
@@ -6271,6 +7727,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 108,
+                    "plug": 12,
+                    "serial": 1002,
+                    "slot": 2
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 6,
@@ -6297,6 +7760,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 109,
+                    "plug": 13,
+                    "serial": 1002,
+                    "slot": 2
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 7,
@@ -6323,6 +7793,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 66,
+                    "plug": 2,
+                    "serial": 24096,
+                    "slot": 0
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 0,
@@ -6349,6 +7826,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 67,
+                    "plug": 3,
+                    "serial": 24096,
+                    "slot": 0
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 2,
@@ -6375,6 +7859,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 68,
+                    "plug": 4,
+                    "serial": 24096,
+                    "slot": 0
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 2,
@@ -6401,6 +7892,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 59,
+                    "plug": 3,
+                    "serial": 29647,
+                    "slot": 6
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 1,
@@ -6427,6 +7925,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 60,
+                    "plug": 4,
+                    "serial": 29647,
+                    "slot": 6
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 4,
@@ -6453,6 +7958,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 61,
+                    "plug": 5,
+                    "serial": 29647,
+                    "slot": 6
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 4,
@@ -6479,6 +7991,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 110,
+                    "plug": 0,
+                    "serial": 24681,
+                    "slot": 3
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 0,
@@ -6505,6 +8024,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 111,
+                    "plug": 1,
+                    "serial": 24681,
+                    "slot": 3
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 1,
@@ -6531,6 +8057,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 112,
+                    "plug": 2,
+                    "serial": 24681,
+                    "slot": 3
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 1,
@@ -6557,6 +8090,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 113,
+                    "plug": 3,
+                    "serial": 24681,
+                    "slot": 3
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 2,
@@ -6583,6 +8123,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 69,
+                    "plug": 5,
+                    "serial": 24096,
+                    "slot": 0
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 3,
@@ -6609,6 +8156,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 70,
+                    "plug": 6,
+                    "serial": 24096,
+                    "slot": 0
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 3,
@@ -6635,6 +8189,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 71,
+                    "plug": 7,
+                    "serial": 24096,
+                    "slot": 0
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 4,
@@ -6661,6 +8222,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 72,
+                    "plug": 8,
+                    "serial": 24096,
+                    "slot": 0
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 5,
@@ -6687,6 +8255,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 62,
+                    "plug": 6,
+                    "serial": 29647,
+                    "slot": 6
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 5,
@@ -6713,6 +8288,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 0,
+                    "fan": 63,
+                    "plug": 7,
+                    "serial": 29647,
+                    "slot": 6
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 6,
@@ -6739,6 +8321,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 114,
+                    "plug": 4,
+                    "serial": 24681,
+                    "slot": 3
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 2,
@@ -6765,6 +8354,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 115,
+                    "plug": 5,
+                    "serial": 24681,
+                    "slot": 3
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 3,
@@ -6791,6 +8387,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 116,
+                    "plug": 6,
+                    "serial": 24681,
+                    "slot": 3
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 2,
@@ -6817,6 +8420,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 73,
+                    "plug": 9,
+                    "serial": 24096,
+                    "slot": 0
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 5,
@@ -6843,6 +8453,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 74,
+                    "plug": 10,
+                    "serial": 24096,
+                    "slot": 0
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 7,
@@ -6869,6 +8486,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 75,
+                    "plug": 11,
+                    "serial": 24096,
+                    "slot": 0
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 6,
@@ -6895,6 +8519,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 76,
+                    "plug": 12,
+                    "serial": 24096,
+                    "slot": 0
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 6,
@@ -6921,6 +8552,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 77,
+                    "plug": 13,
+                    "serial": 24096,
+                    "slot": 0
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 6,
@@ -6947,6 +8585,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 78,
+                    "plug": 14,
+                    "serial": 24096,
+                    "slot": 0
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 7,
@@ -6973,6 +8618,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 117,
+                    "plug": 7,
+                    "serial": 24681,
+                    "slot": 3
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 4,
@@ -6999,6 +8651,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 118,
+                    "plug": 8,
+                    "serial": 24681,
+                    "slot": 3
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 4,
@@ -7025,6 +8684,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 119,
+                    "plug": 9,
+                    "serial": 24681,
+                    "slot": 3
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 5,
@@ -7051,6 +8717,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 79,
+                    "plug": 15,
+                    "serial": 24096,
+                    "slot": 0
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 7,
@@ -7077,6 +8750,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 80,
+                    "plug": 0,
+                    "serial": 24672,
+                    "slot": 1
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 1,
@@ -7103,6 +8783,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 81,
+                    "plug": 1,
+                    "serial": 24672,
+                    "slot": 1
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 1,
@@ -7129,6 +8816,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 82,
+                    "plug": 2,
+                    "serial": 24672,
+                    "slot": 1
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 1,
@@ -7155,6 +8849,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 83,
+                    "plug": 3,
+                    "serial": 24672,
+                    "slot": 1
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 2,
@@ -7181,6 +8882,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 120,
+                    "plug": 10,
+                    "serial": 24681,
+                    "slot": 3
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 6,
@@ -7207,6 +8915,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 84,
+                    "plug": 4,
+                    "serial": 24672,
+                    "slot": 1
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 3,
@@ -7233,6 +8948,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 85,
+                    "plug": 5,
+                    "serial": 24672,
+                    "slot": 1
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 4,
@@ -7259,6 +8981,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 86,
+                    "plug": 6,
+                    "serial": 24672,
+                    "slot": 1
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 4,
@@ -7285,6 +9014,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": 87,
+                    "plug": 7,
+                    "serial": 24672,
+                    "slot": 1
+                },
                 "array": "bottom",
                 "digitizer": {
                     "channel": 5,
@@ -7311,6 +9047,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 10,
+                    "serial": 24678,
+                    "slot": 7
+                },
                 "array": "diagnostic",
                 "digitizer": {
                     "channel": 4,
@@ -7337,6 +9080,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 11,
+                    "serial": 24678,
+                    "slot": 7
+                },
                 "array": "diagnostic",
                 "digitizer": {
                     "channel": 4,
@@ -7363,6 +9113,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 12,
+                    "serial": 24678,
+                    "slot": 7
+                },
                 "array": "diagnostic",
                 "digitizer": {
                     "channel": 4,
@@ -7389,6 +9146,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 13,
+                    "serial": 24678,
+                    "slot": 7
+                },
                 "array": "diagnostic",
                 "digitizer": {
                     "channel": 6,
@@ -7415,6 +9179,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 14,
+                    "serial": 24678,
+                    "slot": 7
+                },
                 "array": "diagnostic",
                 "digitizer": {
                     "channel": 6,
@@ -7441,6 +9212,13 @@ pmts  = [
                 }
             },
             {
+                "amplifier": {
+                    "crate": 1,
+                    "fan": -1,
+                    "plug": 15,
+                    "serial": 24678,
+                    "slot": 7
+                },
                 "array": "diagnostic",
                 "digitizer": {
                     "channel": 6,


### PR DESCRIPTION
These are some small changes to the cable map json in XENON1T.ini:
* Separate connector and channel fields. So no more strings '8.04', but separate integer fields `connector=8` and `channel=4`.
* PMT serial numbers now stored as ints, not floats 
* Add amplifier information. I thought I already did this... but apparently I forgot to commit it.

I also correct an error I introduced in #361: the placeholder gain for the diagnostic PMTs should be 2e6 rather than 4.8e6, since these are 1-inch XENON100 PMTs running at similar voltages as in XENON100.