### PR TITLE
Saner trigger defaults

### DIFF
--- a/pax/config/_base.ini
+++ b/pax/config/_base.ini
@@ -104,12 +104,12 @@ signal_separation = 0.3 * us
 
 # Include this much time left and right of a trigger in an event
 # 'include' means: include any pulses that START within the time range  (TODO: what is logic on boundaries?)
-left_extension = 200 * us
-right_extension = 100 * us
+left_extension = 50 * us
+right_extension = 50 * us
 
 # If no TRIGGERS (says nothing about times or signals) occur within this length of time, a new event can start.
 # Closer triggers will be merged into one event.
-event_separation = 0.5 * ms
+event_separation = 100 * units.us
 
 
 [Trigger.FindSignals]
@@ -144,9 +144,9 @@ s2_min_pulses = 10
 #
 # Be careful if you set a nonzero trigger probability for the 'unknown' peaks,
 # these are very easily made by exponential noise.
-trigger_probability = {'0': {'2': 0},
-                       '1': {'10': 0.1},
-                       '2': {'10': 0.1, '50': 1}}
+trigger_probability = {'0': {'50': 1},
+                       '1': {'50': 1},
+                       '2': {'50': 1}}
 
 
 [Trigger.GroupTriggers]

--- a/pax/config/_base.ini
+++ b/pax/config/_base.ini
@@ -109,7 +109,7 @@ right_extension = 50 * us
 
 # If no TRIGGERS (says nothing about times or signals) occur within this length of time, a new event can start.
 # Closer triggers will be merged into one event.
-event_separation = 100 * units.us
+event_separation = 100 * us
 
 
 [Trigger.FindSignals]


### PR DESCRIPTION
This sets the default trigger settings to the ones we used over the last few weeks: trigger always above 50 pulses, with 50 us left and right of each trigger. This will capture high-energy events up to 100us apart (since both the S1 and S2 trigger).

Last week we set these settings manually or via a custom config file. When the rate has gone down and the lifetime has gone up, we should of course put wider left and right extensions.