### PR TITLE
Avoid numpy runtime warnings from failed confidence contours

### DIFF
--- a/pax/PatternFitter.py
+++ b/pax/PatternFitter.py
@@ -235,8 +235,6 @@ class PatternFitter(object):
         """
         gofs, lowest_indices = self.compute_gof_grid(center_coordinates, grid_size, areas_observed,
                                                   pmt_selection, square_syst_errors, statistic, plot)
-        if np.all(np.isnan(gofs)):
-            raise ValueError("Goodness of fit values are all NaN??")
         min_index = np.unravel_index(np.nanargmin(gofs), gofs.shape)
         # Convert index back to position
         result = []


### PR DESCRIPTION
We currently get the message

    /home/jelle/anaconda3/envs/pax/lib/python3.4/site-packages/numpy/lib/nanfunctions.py:227: RuntimeWarning: All-NaN axis encountered
      warnings.warn("All-NaN axis encountered", RuntimeWarning)

every ~50 events so. This happens when a list in the confidence contour calculation contains only NaN values. 

@pelssers maybe you'd like to have a look at these edge cases later. For now I just avoided the warning by leaving the confidencetuple's values at nan (which would probably have been the result anyway).