### PR TITLE
Configurable DeleteLowLevelInfo

### DIFF
--- a/pax/plugins/DeleteLowLevelInfo.py
+++ b/pax/plugins/DeleteLowLevelInfo.py
@@ -3,22 +3,40 @@ import numpy as np
 
 
 class DeleteLowLevelInfo(plugin.TransformPlugin):
-    """This deletes all low-level info from the datastructure, to make the output file smaller
-    This is what gets removed:
+    """This deletes low-level info from the datastructure, to make the output file smaller.
+    By default, this is what gets removed:
       * hits for all but the main s1
       * pulses for all but the main s1
-      * sum waveforms (but not the peak sum waveforms... maybe in the future)
+      * sum waveforms (but not the peak sum waveforms stored with each peak)
     """
 
     def transform_event(self, event):
-        pulses_to_keep = []
-        for p in event.peaks:
-            if p.type == 's1':
-                pulses_to_keep.extend(p.hits['found_in_pulse'].tolist())
-            else:
-                p.hits = p.hits[:0]   # Set hits to an empty array
-        pulses_to_keep = np.unique(pulses_to_keep)
-        event.all_hits = event.all_hits[:0]
-        event.pulses = [p for i, p in enumerate(event.pulses) if i in pulses_to_keep]
-        event.sum_waveforms = []
+
+        if self.config.get('delete_sum_waveforms', True):
+            event.sum_waveforms = []
+
+        delopt = self.config.get('delete_hits_and_pulses', 'not_for_s1s')
+
+        if not delopt or delopt == 'none':
+            return
+
+        elif delopt == 'not_for_s1s':
+            pulses_to_keep = []
+            for p in event.peaks:
+                if p.type == 's1':
+                    pulses_to_keep.extend(p.hits['found_in_pulse'].tolist())
+                else:
+                    p.hits = p.hits[:0]   # Set hits to an empty array
+            pulses_to_keep = np.unique(pulses_to_keep)
+            event.all_hits = event.all_hits[:0]
+            event.pulses = [p for i, p in enumerate(event.pulses) if i in pulses_to_keep]
+
+        elif delopt == 'all':
+            event.pulses = []
+            for p in event.peaks:
+                p.hits = p.hits[:0]
+
+        else:
+            raise ValueError("Illegal delete_hits_and_pulses value %s" % delopt)
+
         return event


### PR DESCRIPTION
This is a minor change to make DeleteLowLevelInfo, the plugin which removes low-level info from the datastructure, configurable. By setting `delete_hits_and_pulses = False`, for example, you can output hits and pulses for all peaks, but still not output the event sum waveforms (which would probably crash the  output, since we don't support variable-length numpy arrays).