### PR TITLE
Fix for root class creation if no peaks in first event

### DIFF
--- a/pax/datastructure.py
+++ b/pax/datastructure.py
@@ -185,6 +185,7 @@ class Peak(StrictModel):
 
     #: The hits that make up this peak
     #: To save space, we usually only store the hits for s1s.
+    #: For the root output, this gets converted back to a list of Hit classes (then to a vector of c++ Hit objects)
     hits = np.array([], dtype=Hit.get_dtype())
 
     #: Total areas of all hits per PMT (pe).


### PR DESCRIPTION
This fixes an error reported by Patrick and Alfio where, if the first event we process does not contain a peak, the resulting root class is not created correctly, and processing may eventually crash. 

The C++ class creation code requires an instance of a datastructure class (like Peak) rather than just the class itself. The class code does not hardcode the length of fixed-length array fields (such as peak.area_per_channel), so we can use pax for multiple TPCs by just changing the configuration.

When the first event we process has no peak (or another datastructure, such as Interaction or ConfidenceTuple), pax attempts to create an empty peak (or Interaction or ConfidenceTuple). This fix sets the array lengths of that empty peak correctly based on the configuration.

This is no long-term solution: it requires the root output code to go digging into all kinds of places in the config where it is not supposed to go. We can try to abandon fixed-length arrays altogether and change everything into vectors, or modify the default values of fields after we've loaded the configuration.