### PR TITLE
Simplify installation and dependencies by using uniform anaconda environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,8 @@ install:
   - conda config --add channels defaults
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --add channels http://conda.anaconda.org/XENON1T
-  - if [ "${PYTHON}" == 3.4 ]; conda env create -n pax_head XENON1T/pax_head; conda install -n pax_head root=${ROOT}; fi  # this is python3
+  - if [ "${PYTHON}" == 3.4 ]; conda env create -n pax_head XENON1T/pax_head; fi  # this is python3
+  - if [ "${PYTHON}" == 3.4 ]; conda install -n pax_head root=${ROOT}; fi  # this is python3
   - if [ "${PYTHON}" == 2.7 ]; conda install -q -n pax_head python=${PYTHON} root=${ROOT} numpy scipy=0.16 matplotlib pandas cython h5py numba pip python-snappy pytables scikit-learn rootpy psutil jupyter; fi
   - source activate pax_head
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ install:
   - conda config --add channels defaults
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --add channels http://conda.anaconda.org/XENON1T
-  - conda env create -q -n pax_head XENON1T/pax_head
+  - conda env create -q -n pax_head -f XENON1T/pax_head
   - conda install -q -n pax_head python=${PYTHON} root=${ROOT} six psutil numexpr
   - source activate pax_head
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,8 +69,8 @@ install:
   - conda info -a # Useful for debugging any issues with conda
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --add channels http://conda.anaconda.org/XENON1T
-  - conda env create -n pax XENON1T/pax_head
-  - conda install -n pax python=${PYTHON} root=${ROOT} 
+  - conda env create -q -n pax XENON1T/pax_head
+  - conda install -q -n pax python=${PYTHON} root=${ROOT} 
   - source activate pax
 
   # Install pax

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,14 +65,13 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda install -q anaconda-client conda conda-env
+  - conda install -q anaconda-client conda=3.19.3 conda-env=2.4.5
   - conda info -a # Useful for debugging any issues with conda
   - conda config --add channels defaults
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --add channels http://conda.anaconda.org/XENON1T
   - conda env create -q -n pax_head XENON1T/pax_head
-  - source activate pax_head
-  - conda install -q python=${PYTHON} root=${ROOT} 
+  - conda install -q -n pax_head python=${PYTHON} root=${ROOT} 
   - source activate pax_head
 
   # Install pax

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ install:
   - conda config --add channels http://conda.anaconda.org/XENON1T
   - conda env create -n pax_head XENON1T/pax_head  # this is python3
   - conda install -q -n pax_head python=${PYTHON} root=${ROOT}
-  - if [ "${PYTHON}" == 2.7 ]; then conda install six psutil numexpr cython h5py; fi
+  - if [ "${PYTHON}" == 2.7 ]; then conda install -n pax_head six psutil numexpr cython h5py; fi
   - source activate pax_head
 
   # Install pax

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda install -q binstar conda conda-env
+  - conda install -q anaconda-client conda conda-env
   - conda info -a # Useful for debugging any issues with conda
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --add channels http://conda.anaconda.org/XENON1T

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ install:
   - conda config --add channels defaults
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --add channels http://conda.anaconda.org/XENON1T
-  - conda env create -q -n pax_head -f XENON1T/pax_head
+  - conda env create -n pax_head XENON1T/pax_head
   - conda install -q -n pax_head python=${PYTHON} root=${ROOT} six psutil numexpr
   - source activate pax_head
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda install -q binstar conda
+  - conda install -q binstar conda conda-env
   - conda info -a # Useful for debugging any issues with conda
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --add channels http://conda.anaconda.org/XENON1T

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,8 +70,8 @@ install:
   - conda config --add channels defaults
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --add channels http://conda.anaconda.org/XENON1T
-  - if [ "${PYTHON}" == "3.4" ]; then conda env create -n pax_head XENON1T/pax_head; conda install -n pax_head root=${ROOT}; fi  # this is python3
-  - if [ "${PYTHON}" == "2.7" ]; then conda install -q -n pax_head python=${PYTHON} root=${ROOT} numpy scipy=0.16 matplotlib pandas cython h5py numba pip python-snappy pytables scikit-learn rootpy psutil jupyter; fi
+  - if [ "${PYTHON}" == "3.4" ]; then conda env create -q -n pax_head XENON1T/pax_head; conda install -q -n pax_head root=${ROOT}; fi  # this is python3
+  - if [ "${PYTHON}" == "2.7" ]; then conda create -q -n pax_head python=${PYTHON} root=${ROOT} numpy scipy=0.16 matplotlib pandas cython h5py numba pip python-snappy pytables scikit-learn rootpy psutil jupyter; fi
   - source activate pax_head
 
   # Install pax

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ install:
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --add channels http://conda.anaconda.org/XENON1T
   - conda env create -q -n pax_head XENON1T/pax_head
-  - conda install -q -n pax_head python=${PYTHON} root=${ROOT} six
+  - conda install -q -n pax_head python=${PYTHON} root=${ROOT} six psutil
   - source activate pax_head
 
   # Install pax

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,8 +69,7 @@ install:
   - conda info -a # Useful for debugging any issues with conda
   - conda config --add channels defaults
   - conda config --add channels http://conda.anaconda.org/NLeSC
-  - conda config --add channels http://conda.anaconda.org/XENON1T
-  - if [ "${PYTHON}" == "3.4" ]; then conda env create -q -n pax_head XENON1T/pax_head; conda install -q -n pax_head root=${ROOT}; fi  # this is python3
+  - if [ "${PYTHON}" == "3.4" ]; then conda config --add channels http://conda.anaconda.org/XENON1T; conda env create -q -n pax_head XENON1T/pax_head; conda install -q -n pax_head root=${ROOT}; fi  # this is python3
   - if [ "${PYTHON}" == "2.7" ]; then conda create -q -n pax_head python=${PYTHON} root=${ROOT} numpy scipy=0.16 matplotlib pandas cython h5py numba pip python-snappy pytables scikit-learn rootpy psutil jupyter; fi
   - source activate pax_head
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ install:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
+  - conda install -q binstar conda
   - conda info -a # Useful for debugging any issues with conda
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --add channels http://conda.anaconda.org/XENON1T

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,9 +70,8 @@ install:
   - conda config --add channels defaults
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --add channels http://conda.anaconda.org/XENON1T
-  - conda env create -n pax_head XENON1T/pax_head  # this is python3
-  - conda install -q -n pax_head python=${PYTHON} root=${ROOT}
-  - if [ "${PYTHON}" == 2.7 ]; then conda install -n pax_head six psutil numexpr cython h5py; fi
+  - if [ "${PYTHON}" == 3.4 ]; conda env create -n pax_head XENON1T/pax_head; conda install -n pax_head root=${ROOT}; fi  # this is python3
+  - if [ "${PYTHON}" == 2.7 ]; conda install -q -n pax_head python=${PYTHON} root=${ROOT} numpy scipy=0.16 matplotlib pandas cython h5py numba pip python-snappy pytables scikit-learn rootpy psutil jupyter; fi
   - source activate pax_head
 
   # Install pax

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,8 @@ install:
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --add channels http://conda.anaconda.org/XENON1T
   - conda env create -n pax_head XENON1T/pax_head  # this is python3
-  - conda install -q -n pax_head python=${PYTHON} root=${ROOT} six psutil numexpr cython
+  - conda install -q -n pax_head python=${PYTHON} root=${ROOT}
+  - if [ "${PYTHON}" == 2.7 ]; then conda install six psutil numexpr cython h5py; fi
   - source activate pax_head
 
   # Install pax

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,9 +70,10 @@ install:
   - conda config --add channels defaults
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --add channels http://conda.anaconda.org/XENON1T
-  - conda env create -q -n pax XENON1T/pax_head
-  - conda install -q -n pax python=${PYTHON} root=${ROOT} 
-  - source activate pax
+  - conda env create -q -n pax_head XENON1T/pax_head
+  - source activate pax_head
+  - conda install -q python=${PYTHON} root=${ROOT} 
+  - source activate pax_head
 
   # Install pax
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ install:
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --add channels http://conda.anaconda.org/XENON1T
   - conda env create -q -n pax_head XENON1T/pax_head
-  - conda install -q -n pax_head python=${PYTHON} root=${ROOT} six psutil
+  - conda install -q -n pax_head python=${PYTHON} root=${ROOT} six psutil numexpr
   - source activate pax_head
 
   # Install pax

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,7 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda install -q anaconda-client conda conda-env
   - conda info -a # Useful for debugging any issues with conda
+  - conda config --add channels defaults
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --add channels http://conda.anaconda.org/XENON1T
   - conda env create -q -n pax XENON1T/pax_head

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ install:
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --add channels http://conda.anaconda.org/XENON1T
   - conda env create -q -n pax_head XENON1T/pax_head
-  - conda install -q -n pax_head python=${PYTHON} root=${ROOT} 
+  - conda install -q -n pax_head python=${PYTHON} root=${ROOT} six
   - source activate pax_head
 
   # Install pax

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,12 +67,11 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
   - conda info -a # Useful for debugging any issues with conda
-  - conda config --add channels http://conda.anaconda.org/NLeSC  
-  - conda create -q -n pax python=${PYTHON} root=${ROOT} numpy scipy=0.16 matplotlib pandas cython h5py numba pip python-snappy pytables scikit-learn rootpy psutil jupyter
+  - conda config --add channels http://conda.anaconda.org/NLeSC
+  - conda config --add channels http://conda.anaconda.org/XENON1T
+  - conda env create -n pax XENON1T/pax_head
+  - conda install -n pax python=${PYTHON} root=${ROOT} 
   - source activate pax
-  # tmp hack will be fixed
-  # - conda uninstall -q sqlite libpng libx11 
-  - pip install coveralls nose coverage
 
   # Install pax
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,8 +70,8 @@ install:
   - conda config --add channels defaults
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --add channels http://conda.anaconda.org/XENON1T
-  - conda env create -n pax_head XENON1T/pax_head
-  - conda install -q -n pax_head python=${PYTHON} root=${ROOT} six psutil numexpr
+  - conda env create -n pax_head XENON1T/pax_head  # this is python3
+  - conda install -q -n pax_head python=${PYTHON} root=${ROOT} six psutil numexpr cython
   - source activate pax_head
 
   # Install pax

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,9 +70,8 @@ install:
   - conda config --add channels defaults
   - conda config --add channels http://conda.anaconda.org/NLeSC
   - conda config --add channels http://conda.anaconda.org/XENON1T
-  - if [ "${PYTHON}" == 3.4 ]; conda env create -n pax_head XENON1T/pax_head; fi  # this is python3
-  - if [ "${PYTHON}" == 3.4 ]; conda install -n pax_head root=${ROOT}; fi  # this is python3
-  - if [ "${PYTHON}" == 2.7 ]; conda install -q -n pax_head python=${PYTHON} root=${ROOT} numpy scipy=0.16 matplotlib pandas cython h5py numba pip python-snappy pytables scikit-learn rootpy psutil jupyter; fi
+  - if [ "${PYTHON}" == "3.4" ]; then conda env create -n pax_head XENON1T/pax_head; conda install -n pax_head root=${ROOT}; fi  # this is python3
+  - if [ "${PYTHON}" == "2.7" ]; then conda install -q -n pax_head python=${PYTHON} root=${ROOT} numpy scipy=0.16 matplotlib pandas cython h5py numba pip python-snappy pytables scikit-learn rootpy psutil jupyter; fi
   - source activate pax_head
 
   # Install pax

--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ You can put this in your `.bashrc` if you want it to be setup when you login. Fo
 
 -----------------------------------
 
-Of course we assume you have a functional basic compilation environment. On a fresh Ubuntu you may have to do e.g.
+Of course we assume you have a functional basic compilation environment. On a fresh Ubuntu you may have to do e.g.::
 
   sudo apt-get install build-essential
   

--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ Pax depends on several other python packages. While most python packages will in
 some contain C++ code which must be compiled. With Anaconda you can get appropriate binaries 
 for your platform using the `conda` tool as follows. Make sure to replace <environment_name> with the desired name of your environment (usually it is 'pax' for central installations) in the following command::
 
-  conda update conda
+  conda install -q anaconda-client conda conda-env
   conda env create -n pax_environment_name XENON1T/pax_head
 
 You can replace "pax_environment_name" with whatever.  Whenever you want to use `pax`, you have to run the following command to set it up your environment (containing all the dependencies)::

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,8 @@ For both Linux and Mac OS X::
 
 You need to point Anaconda to the physics-specific packages e.g. ROOT.  You can do this by running the following::
 
-  conda config --add channels http://conda.anaconda.org/NLeSC  
+  conda config --add channels http://conda.anaconda.org/NLeSC 
+  conda config --add channels http://conda.anaconda.org/XENON1T 
 
 
 Check that no other ROOT is seen
@@ -80,13 +81,11 @@ some contain C++ code which must be compiled. With Anaconda you can get appropri
 for your platform using the `conda` tool as follows. Make sure to replace <environment_name> with the desired name of your environment (usually it is 'pax' for central installations) in the following command::
 
   conda update conda
-  conda create -n <environment_name> python=3.4 root=6 numpy scipy=0.16 matplotlib pandas cython h5py numba pip python-snappy pytables scikit-learn rootpy pymongo psutil jupyter
+  conda env create -n pax_environment_name XENON1T/pax_head
 
-If you do not want ROOT support, or have ROOT-related issues, you can leave out root and rootpy in the above command. Everything in pax, except of course ROOT I/O, will continue to work. You can also try root=6 for the newer version of ROOT.
-
-Whenever you want to use `pax`, you have to run the following command to set it up your environment (containing all the dependencies)::
+You can replace "pax_environment_name" with whatever.  Whenever you want to use `pax`, you have to run the following command to set it up your environment (containing all the dependencies)::
   
-  source activate <environment_name>
+  source activate pax_environment_name
   
 You can put this in your `.bashrc` if you want it to be setup when you login. For the rest of the installation and to run pax, be sure to be inside this environment. There should be (<environment_name>) at the beginning of your command line.
 


### PR DESCRIPTION
As of now, all Anaconda environments everywhere (Midway, Stockholm, LNGS, test server, etc.) should be the same.  This is done by setting up an environment in Anaconda cloud:

https://anaconda.org/XENON1T/pax_head

This is currently a copy of the Midway environment.  I setup TravisCI to also use this.  This should reduce bookkeeping.

Soon I hope we can also just do `conda install pax` etc