### PR TITLE
Trigger config from runmodes

### DIFF
--- a/bin/event-builder
+++ b/bin/event-builder
@@ -21,7 +21,7 @@ import shutil
 from six.moves import input
 import pymongo
 
-from pax import core, units
+from pax import core, units, configuration
 from pax.MongoDB_ClientMaker import ClientMaker
 
 
@@ -94,16 +94,17 @@ def main():
 
         # Build configuration for pax. Settings priority:
         #   First priority: command line args
-        #   Second priority: rundb's trigger mode, in future complete override settings
+        #   Second priority: rundoc's trigger mode and trigger_config_override (latter has higher priority)
         #   Third priority: defaults from pax configuration (pax will take care of loading these)
         # Unit conversion factors are applied to the command line args, but NOT to the rundb values!
         # (to do that, we'd have to un-convert them when we later store the settings we actually used)
 
         # Load run doc settings + basic settings
         # This is a
+        config_dict = {}
         trigger_mode = run_doc['reader']['ini']['trigger_mode']
         if trigger_mode.startswith('triggered'):
-            log.debug("Picking up triggered mode: trigger_mode is %s" % trigger_mode)
+            log.info("Picked up triggered mode %s, special settings activated" % trigger_mode)
             config_dict = {"Trigger": {
                                "left_extension": 10 * units.us,
                                "right_extension": 1010 * units.us if trigger_mode.endswith('long') else 100 * units.us
@@ -115,18 +116,18 @@ def main():
                                    "2": {"2": 1}
                                }
                            }}
-        else:
-            config_dict = {}
 
-        # FUTURE: Get a complete override dict from run ini instead
-        # run_doc should not try to override something from 'pax', 'DEFAULT', etc.
-        # config_dict = run_doc['reader']['ini'].get('trigger_configuration_override', {})
-        config_dict.update({'DEFAULT': {'run_doc_id': run_doc['_id'],
-                                        'run_number': run_doc['number']},
-                            'pax': {'output_name': data_info_entry['location'],
-                                    'n_cpus': args.cpus},
-                            'BSON': {'fields_to_ignore': [],
-                                     'overwrite_output': True}})
+        config_dict = configuration.combine_configs(config_dict, {
+            'DEFAULT': {'run_doc_id': run_doc['_id'],
+                        'run_number': run_doc['number']},
+            'pax': {'output_name': data_info_entry['location'],
+                    'n_cpus': args.cpus},
+            'BSON': {'fields_to_ignore': [],
+                     'overwrite_output': True}})
+
+        # Set any extra settings specified in the run doc
+        config_dict = configuration.combine_configs(config_dict,
+                                                    run_doc['reader']['ini'].get('trigger_config_override', {}))
 
         # Apply command-line override settings for MongoDB
         mongo_settings_override = {}
@@ -140,11 +141,11 @@ def main():
             if argname in ('edge_safety_margin', 'batch_window'):
                 argval *= units.s
             mongo_settings_override[argname] = argval
-        config_dict.setdefault('MongoDB', {})
-        config_dict['MongoDB'].update(mongo_settings_override)
+        config_dict = configuration.combine_configs(config_dict, dict(MongoDB=mongo_settings_override))
 
         # Apply command-line override settings for trigger
-        trigger_settings_override = {}
+        trigger_settings_override = {'trigger_monitor_file_path': os.path.join(data_info_entry['location'],
+                                                                               'trigger_monitor_data.zip')}
         for argname, factor in (('left_extension', units.us),
                                 ('right_extension', units.us),
                                 ('signal_separation', units.us),
@@ -154,19 +155,15 @@ def main():
                 if factor is not None:
                     argval = int(factor * argval)
                 trigger_settings_override[argname] = argval
-        trigger_settings_override['trigger_monitor_file_path'] = os.path.join(data_info_entry['location'],
-                                                                              'trigger_monitor_data.zip')
-        config_dict.setdefault('Trigger', {})
-        config_dict['Trigger'].update(trigger_settings_override)
+        config_dict = configuration.combine_configs(config_dict, dict(Trigger=trigger_settings_override))
 
         # Apply command-line override settings for trigger probability
         if args.force_multiplicity_trigger is not None:
-            level = args.force_multiplicity_trigger
-            config_dict.setdefault('Trigger.DecideTriggers', {})
-            config_dict['Trigger.DecideTriggers']['trigger_probability'] = {
-                '0': {str(level): 1},
-                '1': {str(level): 1},
-                '2': {str(level): 1}}
+            str_level = str(args.force_multiplicity_trigger)
+            config_dict = configuration.combine_configs(config_dict, {'Trigger.DecideTriggers': {
+                '0': {str_level: 1},
+                '1': {str_level: 1},
+                '2': {str_level: 1}}})
 
         log.info("Building events for %s", run_doc['name'])
         log.debug("Config override is: %s" % config_dict)
@@ -176,22 +173,24 @@ def main():
                                config_dict=config_dict)
             p.run()     # The run() method includes a call to shutdown()
 
-        # If a timeout occurred, set the status of this run to 'error'
-        # Add other exceptions as they come during commissioning
-        except pymongo.errors.ServerSelectionTimeoutError as e:
+        except Exception as e:
+            # There was some problem -- maybe next run will be better
             log.exception(e)
-            runs.update({'name': run_doc['name'], 'detector' : args.detector},
-                        {'$set': {status_name: 'error'}})
+            if not args.secret_mode:
+                runs.update({'name': run_doc['name'], 'detector': args.detector},
+                            {'$set': {status_name: 'error'}})
+
+        else:
+            # Things went fine :-)
+            if not args.secret_mode:
+                data_info_entry['status'] = 'verifying'
+                runs.update({'_id': run_doc['_id'],
+                             'data.host': data_info_entry['host']},
+                            {'$set': {'data.$': data_info_entry}})
 
         # Copy the log file to the output dir, then clear it for the next run
         shutil.copyfile('eventbuilder.log', data_info_entry['location'] + '/eventbuilder.log')
         open('eventbuilder.log', mode='w').close()
-
-        if not args.secret_mode:
-            data_info_entry['status'] = 'verifying'
-            runs.update({'_id': run_doc['_id'],
-                         'data.host': data_info_entry['host']},
-                        {'$set': {'data.$': data_info_entry}})
 
         # If we're trying to build a single run, don't try again to find it
         if args.run_name or args.run:

--- a/bin/event-builder
+++ b/bin/event-builder
@@ -166,7 +166,7 @@ def main():
                 '2': {str_level: 1}}})
 
         log.info("Building events for %s", run_doc['name'])
-        log.debug("Config override is: %s" % config_dict)
+        log.info("Config override is: %s" % config_dict)
         try:
             p = core.Processor(config_names=['XENON1T' if args.detector == 'tpc' else 'XENON1T_MV'] + args.config,
                                config_paths=args.config_path,

--- a/bin/event-builder
+++ b/bin/event-builder
@@ -19,9 +19,9 @@ import socket
 import shutil
 
 from six.moves import input
-import pymongo
 
-from pax import core, units, configuration
+from pax import core, units
+from pax.configuration import combine_configs, fix_sections_from_mongo
 from pax.MongoDB_ClientMaker import ClientMaker
 
 
@@ -117,7 +117,7 @@ def main():
                                }
                            }}
 
-        config_dict = configuration.combine_configs(config_dict, {
+        config_dict = combine_configs(config_dict, {
             'DEFAULT': {'run_doc_id': run_doc['_id'],
                         'run_number': run_doc['number']},
             'pax': {'output_name': data_info_entry['location'],
@@ -126,8 +126,8 @@ def main():
                      'overwrite_output': True}})
 
         # Set any extra settings specified in the run doc
-        config_dict = configuration.combine_configs(config_dict,
-                                                    run_doc['reader']['ini'].get('trigger_config_override', {}))
+        mongo_conf = fix_sections_from_mongo(run_doc['reader']['ini'].get('trigger_config_override', {}))
+        config_dict = combine_configs(config_dict, mongo_conf)
 
         # Apply command-line override settings for MongoDB
         mongo_settings_override = {}
@@ -141,7 +141,7 @@ def main():
             if argname in ('edge_safety_margin', 'batch_window'):
                 argval *= units.s
             mongo_settings_override[argname] = argval
-        config_dict = configuration.combine_configs(config_dict, dict(MongoDB=mongo_settings_override))
+        config_dict = combine_configs(config_dict, dict(MongoDB=mongo_settings_override))
 
         # Apply command-line override settings for trigger
         trigger_settings_override = {'trigger_monitor_file_path': os.path.join(data_info_entry['location'],
@@ -155,12 +155,12 @@ def main():
                 if factor is not None:
                     argval = int(factor * argval)
                 trigger_settings_override[argname] = argval
-        config_dict = configuration.combine_configs(config_dict, dict(Trigger=trigger_settings_override))
+        config_dict = combine_configs(config_dict, dict(Trigger=trigger_settings_override))
 
         # Apply command-line override settings for trigger probability
         if args.force_multiplicity_trigger is not None:
             str_level = str(args.force_multiplicity_trigger)
-            config_dict = configuration.combine_configs(config_dict, {'Trigger.DecideTriggers': {
+            config_dict = combine_configs(config_dict, {'Trigger.DecideTriggers': {
                 '0': {str_level: 1},
                 '1': {str_level: 1},
                 '2': {str_level: 1}}})
@@ -174,7 +174,7 @@ def main():
             p.run()     # The run() method includes a call to shutdown()
 
         except Exception as e:
-            # There was some problem -- maybe next run will be better
+            # There was some problem -- write it to the log. Set the trigger status to error.
             log.exception(e)
             if not args.secret_mode:
                 runs.update({'name': run_doc['name'], 'detector': args.detector},

--- a/pax/configuration.py
+++ b/pax/configuration.py
@@ -142,4 +142,4 @@ def fix_sections_from_mongo(config):
     """Returns configuration with | replaced with . in section keys.
     Needed because . in field names has special meaning in MongoDB
     """
-    return {k.replace('|', '.'): v for k, v in config}
+    return {k.replace('|', '.'): v for k, v in config.items()}

--- a/pax/configuration.py
+++ b/pax/configuration.py
@@ -115,11 +115,7 @@ def load_configuration(config_names=(), config_paths=(), config_string=None, con
             evaled_config[section_name][key] = eval(value, visible_variables)
 
     # Apply the config_dict
-    for section_name in config_dict.keys():
-        if section_name in evaled_config:
-            evaled_config[section_name].update(config_dict[section_name])
-        else:
-            evaled_config[section_name] = config_dict[section_name]
+    evaled_config = combine_configs(evaled_config, config_dict)
 
     # Make sure [DEFAULT] is at least present
     evaled_config['DEFAULT'] = evaled_config.get('DEFAULT', {})
@@ -127,3 +123,14 @@ def load_configuration(config_names=(), config_paths=(), config_string=None, con
         del evaled_config['Why_doesnt_configparser_let_me_disable_DEFAULT']
 
     return evaled_config
+
+
+def combine_configs(config, overrides):
+    """Apply overrides to config, then returns config.
+    Config and overrides must be configuration dictionaries, i.e. have at most one level of sections.
+    Settings in overrides override settings in config (as you might have guessed).
+    """
+    for section_name, stuff in overrides.items():
+        config.setdefault(section_name, {})
+        config[section_name].update(stuff)
+    return config

--- a/pax/configuration.py
+++ b/pax/configuration.py
@@ -125,12 +125,21 @@ def load_configuration(config_names=(), config_paths=(), config_string=None, con
     return evaled_config
 
 
-def combine_configs(config, overrides):
+def combine_configs(config, override):
     """Apply overrides to config, then returns config.
     Config and overrides must be configuration dictionaries, i.e. have at most one level of sections.
     Settings in overrides override settings in config (as you might have guessed).
     """
-    for section_name, stuff in overrides.items():
+    for section_name, section_config in override.items():
         config.setdefault(section_name, {})
-        config[section_name].update(stuff)
+        if not isinstance(section_config, dict):
+            raise ValueError("COnfiguration dictionary should be a dictionary of dictionaries.")
+        config[section_name].update(section_config)
     return config
+
+
+def fix_sections_from_mongo(config):
+    """Returns configuration with | replaced with . in section keys.
+    Needed because . in field names has special meaning in MongoDB
+    """
+    return {k.replace('|', '.'): v for k, v in config}

--- a/pax/plugins/io/Plotting.py
+++ b/pax/plugins/io/Plotting.py
@@ -34,7 +34,7 @@ class PlotBase(plugin.OutputPlugin):
         if self.config['output_name'] != 'SCREEN':
             self.output_dir = self.config['output_name']
             if not os.path.exists(self.output_dir):
-                os.mself.akedirs(self.output_dir)
+                os.self.makedirs(self.output_dir)
         else:
             self.output_dir = None
 

--- a/pax/plugins/io/Plotting.py
+++ b/pax/plugins/io/Plotting.py
@@ -34,7 +34,7 @@ class PlotBase(plugin.OutputPlugin):
         if self.config['output_name'] != 'SCREEN':
             self.output_dir = self.config['output_name']
             if not os.path.exists(self.output_dir):
-                os.self.makedirs(self.output_dir)
+                os.makedirs(self.output_dir)
         else:
             self.output_dir = None
 

--- a/pax/plugins/io/Plotting.py
+++ b/pax/plugins/io/Plotting.py
@@ -34,7 +34,7 @@ class PlotBase(plugin.OutputPlugin):
         if self.config['output_name'] != 'SCREEN':
             self.output_dir = self.config['output_name']
             if not os.path.exists(self.output_dir):
-                os.makedirs(self.output_dir)
+                os.mself.akedirs(self.output_dir)
         else:
             self.output_dir = None
 
@@ -750,11 +750,12 @@ class PeakViewer(PlotBase):
         self.bot_hitp_sc = self.plot_hitpattern(peak=peak, ax=self.bot_hitp_ax, array='bottom')
 
         # Update peak waveforms
-        peak_padding = 10
+        peak_padding = self.config.get('peak_padding_samples', 30)
         self.plot_waveform(self.event, left=peak.left, right=peak.right,
                            pad=peak_padding, show_legend=False, log_y_axis=False, ax=self.peak_sumwv_ax)
         self.peak_chwvs_ax.set_xlim((peak.left - peak_padding) * self.chwvs_2s_time_scale,
                                     (peak.right + peak_padding) * self.chwvs_2s_time_scale)
+        self.peak_sumwv_ax.xaxis.set_major_locator(matplotlib.ticker.MaxNLocator(nbins=4))
 
         # Update peak text
 


### PR DESCRIPTION
This allows us to specify overrides for the trigger configuration in the run doc. For example, have a look at the alphas_stable runmode, which has this:

    "trigger_config_override": {
        "Trigger|DecideTriggers": {
          "trigger_probability": {
            "0": { "2": 0},
            "1": {"50": 0.01, "100": 1},
            "2": {"50": 0.01}
          }
        },
        "Trigger|ClassifySignals": {
          "s1_max_rms": 12
        }
    },

which prescales normal signals by 1%, but lets narrow, large-area S1s pass. I tested this with a small run, it seems to work.

The `|` is necessary because `.` in field names has a special meaning in Mongo. It is translated to `.` when the config is loaded.

Also includes a minor plotting fix, and adresses #359 by writing a trigger exception to the log and marking the trigger status of the run as 'error' (as opposed to leaving it 'transferring' forever). 