### PR TITLE
Read out acquisittion monitor channels

### DIFF
--- a/pax/config/XENON1T.ini
+++ b/pax/config/XENON1T.ini
@@ -204,8 +204,8 @@ s2_patterns_zoom_factor =             2
 # Since the peaks noted in that figure add up to 2.9%, but the total afterpulse rate is quoted as 4.9%,
 # I (Jelle) arbitrarily added a 2% probability population with 1us decay time.
 # TODO: Calibrate this more properly once we have data
-# TODO: This should soon become part of the pmts dictionary (/database?), then we'll be able to add PMT-dependent info.
-# The original photon is not yet deleted when an afterpulse is made (but this is such a small effect we probably don't care
+# TODO: Add PMT-dependent info?
+# TODO: The original photon is not yet deleted when an afterpulse is made (but this is such a small effect we probably don't care about)
 pmt_afterpulse_types = {
     'H2':  {'p': 0.002 * 1.8/4.9,
             'time_distribution': 'normal',
@@ -355,8 +355,11 @@ drift_velocity_liquid =         1.73 * um / ns     # PLACEHOLDER: from XENON100
 channels_in_detector = {
     'tpc':   list(range(0,   247+1)),
     'veto':  list(range(248, 253+1)),
+    'sum_wv': [254],
+    'busy': [255],
+    'he_veto': [256],
     }
-n_channels = 254
+n_channels = 257
 
 pmt_0_is_fake = False
 
@@ -632,9 +635,10 @@ gains = [
     2000000.000,    # 251, placeholder: 1-inch XENON100 PMT
     2000000.000,    # 252, placeholder: 1-inch XENON100 PMT
     2000000.000,    # 253, placeholder: 1-inch XENON100 PMT
+    1, 1, 1         # 254-256: Acquisition monitor
     ]
 
-gain_sigmas = [1e6] * 254                          # PLACEHOLDER
+gain_sigmas = [1e6] * 257                          # PLACEHOLDER
 # QES from  https://xecluster.lngs.infn.it/xenon1tpmts/daniel_test/tpc_view_datasheets.php
 # (Hamamatsu datasheets)
 quantum_efficiencies = [
@@ -892,6 +896,7 @@ quantum_efficiencies = [
     0.350,    # 251, placeholder (serial number not known)
     0.350,    # 252, placeholder (serial number not known)
     0.350,    # 253, placeholder (serial number not known)
+    0, 0, 0   #254-256: Acquisition monitor
   ]
 relative_qe_error = 0.02                           # PLACEHOLDER
 
@@ -9282,5 +9287,12 @@ pmts  = [
                     "connector": 5,
                     "feedthrough": 1
                 }
-            }
+            },
+            # Acquisition monitor channels
+            {"digitizer": {"module": 167, "channel": 0},
+             "pmt_position": 254},
+            {"digitizer": {"module": 167, "channel": 1},
+             "pmt_position": 255},
+            {"digitizer": {"module": 167, "channel": 2},
+             "pmt_position": 256},
         ]

--- a/pax/config/XENON1T.ini
+++ b/pax/config/XENON1T.ini
@@ -69,6 +69,22 @@ port = 27017
 user = 'pax'
 
 
+[Plotting]
+waveforms_to_plot = (
+        {'internal_name': 'tpc',      'plot_label': 'TPC (hits only)',
+                    'drawstyle': 'steps', 'color':'black'},
+        {'internal_name': 'tpc_raw',  'plot_label': 'TPC (raw)',
+                    'drawstyle': 'steps', 'color':'black', 'alpha': 0.3},
+        {'internal_name': 'sum_wv_raw',  'plot_label': 'Analog sum',
+                    'drawstyle': 'steps', 'color':'teal', 'alpha': 0.5},
+        {'internal_name': 'busy_raw',  'plot_label': 'BUSY',
+                    'drawstyle': 'steps', 'color':'red'},
+        {'internal_name': 'veto_raw',  'plot_label': 'Diagnostic (raw)',
+                    'drawstyle': 'steps', 'color':'purple', 'alpha': 0.3},
+        {'internal_name': 'veto',  'plot_label': 'Diagnostic (hits only)',
+                    'drawstyle': 'steps', 'color':'purple'},
+    )
+
 
 [HitFinder]
 # For detailed description of what these settings do, see the documentation / plugin docstring.
@@ -635,7 +651,7 @@ gains = [
     2000000.000,    # 251, placeholder: 1-inch XENON100 PMT
     2000000.000,    # 252, placeholder: 1-inch XENON100 PMT
     2000000.000,    # 253, placeholder: 1-inch XENON100 PMT
-    1, 1, 1         # 254-256: Acquisition monitor
+    0.03 * 2.5e6, 1e5, 1e5         # 254-256: Acquisition monitor. Numbers are just to make plots look reasonable, no justification whatsoever
     ]
 
 gain_sigmas = [1e6] * 257                          # PLACEHOLDER
@@ -9290,9 +9306,12 @@ pmts  = [
             },
             # Acquisition monitor channels
             {"digitizer": {"module": 167, "channel": 0},
+             "position": {"x": 0.0, "y": 0.0},
              "pmt_position": 254},
             {"digitizer": {"module": 167, "channel": 1},
+             "position": {"x": 0.0, "y": 0.0},
              "pmt_position": 255},
             {"digitizer": {"module": 167, "channel": 2},
+             "position": {"x": 0.0, "y": 0.0},
              "pmt_position": 256},
         ]

--- a/pax/config/XENON1T.ini
+++ b/pax/config/XENON1T.ini
@@ -651,7 +651,8 @@ gains = [
     2000000.000,    # 251, placeholder: 1-inch XENON100 PMT
     2000000.000,    # 252, placeholder: 1-inch XENON100 PMT
     2000000.000,    # 253, placeholder: 1-inch XENON100 PMT
-    0.03 * 2.5e6, 1e5, 1e5         # 254-256: Acquisition monitor. Numbers are just to make plots look reasonable, no justification whatsoever
+    2.5e6 / 31.25,  # 254, Acquisition monitor sum waveform. Signal is attenuated by 31.25 in NIM FAN, see #392
+    1e5, 1e5        # 255 BUSY, 256 HE-veto. Numbers are just to make plots look reasonable.
     ]
 
 gain_sigmas = [1e6] * 257                          # PLACEHOLDER


### PR DESCRIPTION
This configures pax and the event builder to read out the acquisition monitor channels (see #204). The current acquisition monitor map is:
* Module 167, channel 0 = "PMT" 254: analog sum waveform
* Module 167, channel 1 = "PMT" 255: busy signals. The busy spikes once or twice in very rapid succession (few samples) depending if it turns on or off.
* Module 167, channel 2 = "PMT" 256: high-energy veto. 
Each of these acquisition monitor channel gets its own separate 'detector' in the pax configuration. They also have a gain attached so the sum waveforms actually appear in the event display, although this is now just something I chose to make the plots look reasonable. For the analog sum there probably is a correct value -- does anyone know what it is?

After merging this pull request, the pulse rate in each of these acquisition monitor channels should appear in the trigger monitor; the 'other channels' readout will move to "PMT" 257 automatically. The acquisition monitor data will also appear in the event display:

![aqm_readout_2](https://cloud.githubusercontent.com/assets/4354311/16456745/443ef2be-3e19-11e6-9323-782973611dec.png)

![aqm_readout](https://cloud.githubusercontent.com/assets/4354311/16456767/5e6638aa-3e19-11e6-8d0a-eb6712a30902.png)

As you can see, the busy pulses are delayed by several us, and the analog sum waveform may be slightly delayed as well. If we can't remove this delay, we could correct for it in the event builder. The amplitude offset in the analog sum waveform for some channels is because pax attempts to baseline the pulses in the same way as it does regular PMT pulses, but there is not enough pre- and post- trigger to make this make sense.

I imagine the most important use cases for the acquisition monitor are:
- Rejecting events with a busy/he-veto just before it, and for most analysis probably also events with an interior busy.
- Computing the dead time, i.e. time when the busy/he-veto is active, in the trigger.

There are some outstanding issues to solve before we can do this:
* If possible, the busy-on and busy-off channels should arrive in separate channels. Just sending a slightly different pulse means the trigger has to query and parse each pulse, then recognize the waveform shapes. This will probably be complicated, computationally infeasible and prone to bugs. @buetikofer do you think we could separate on- and off- channels?
* We should store a 'time until last busy' and '... high energy veto' in each event. This is a task for the trigger. 

**Warning:** if we merge this, and take data with it, it cannot be processed anymore by the previous configuration of pax (since, to pax running with old config, there will be data in channels it does not know). This means we need to update the pax version used for processing right away after merging. If you want I can make pax more forgiving of unknown channels (like the trigger / event builder) so we don't have this problem in the future.