### PR TITLE
Eventbuilder upgrade & raw data format change

### DIFF
--- a/pax/MongoDB_ClientMaker.py
+++ b/pax/MongoDB_ClientMaker.py
@@ -31,15 +31,16 @@ class ClientMaker:
         If database_name=None, will connect to the default database of the uri. database=something
         overrides event the uri's specification of a database.
         host is special magic for split_hosts
+        kwargs will be passed to pymongo.mongoclient/Monary
         """
         # Format of URI we should eventually send to mongo
         full_uri_format = 'mongodb://{user}:{password}@{host}:{port}/{database}'
 
         if uri is None:
-            # We must construct the entire URI from default settings
+            # We must construct the entire URI from the settings
             uri = full_uri_format.format(database=database_name, **self.config)
         else:
-            # A URI was NOT given. We expect it to NOT include user and password:
+            # A URI was given. We expect it to NOT include user and password:
             uri_pattern = r'mongodb://([^:]+):(\d+)/(\w+)'
             m = re.match(uri_pattern, uri)
             if m:
@@ -52,7 +53,7 @@ class ClientMaker:
                 uri = full_uri_format.format(database=database_name, host=host, port=port,
                                              user=self.config['user'], password=self.config['password'])
             else:
-                # Some other URI was provided. Maybe works...
+                # Some other URI was provided. Just try it and hope for the best
                 self.log.warning("Unexpected Mongo URI %s, expected format %s. Trying anyway..." % (uri, uri_pattern))
 
         if monary:

--- a/pax/MongoDB_ClientMaker.py
+++ b/pax/MongoDB_ClientMaker.py
@@ -67,6 +67,7 @@ class ClientMaker:
             self.log.debug("Successfully pinged client")
             return client
 
+
 def parse_passwordless_uri(uri):
     """Return host, port, database_name"""
     uri_pattern = r'mongodb://([^:]+):(\d+)/(\w+)'
@@ -76,5 +77,5 @@ def parse_passwordless_uri(uri):
         return m.groups()
     else:
         # Some other URI was provided. Just try it and hope for the best
-        self.log.warning("Unexpected Mongo URI %s, expected format %s." % (uri, uri_pattern))
+        print("Unexpected Mongo URI %s, expected format %s." % (uri, uri_pattern))
         return None

--- a/pax/config/XENON1T.ini
+++ b/pax/config/XENON1T.ini
@@ -7,7 +7,7 @@ parent_configuration = "_base"
 look_for_config_in_runs_db = True
 
 input = 'Zip.ReadZipped'
-decoder_plugin = 'BSON.DecodeZBSON'
+decoder_plugin = 'Pickle.DecodeZPickle'
 
 # Digital signal processing - if you want to repeat any of this,
 # you need to go back to raw data and start from scratch

--- a/pax/config/eventbuilder.ini
+++ b/pax/config/eventbuilder.ini
@@ -43,7 +43,7 @@ skip_ahead = 0
 
 # Maximum number of parallel queries to fire off
 # If delete_data = True, this is also the number of parallel delete queries to fire off
-max_query_workers = 5
+max_query_workers = 20
 
 # When running the trigger live, stay away this far from the insert edge
 edge_safety_margin = 60 * s

--- a/pax/config/eventbuilder.ini
+++ b/pax/config/eventbuilder.ini
@@ -58,3 +58,9 @@ trigger_monitor_mongo_uri = 'mongodb://gw:27018/trigger_monitor'
 [DEFAULT]
 # The run doc's "processor" settings are for data processing, not for the event builder.
 look_for_config_in_runs_db = False
+
+
+# We don't need to load the pattern maps: saves some startup time
+[WaveformSimulator]
+s1_patterns_file = None
+s2_patterns_file = None

--- a/pax/config/eventbuilder.ini
+++ b/pax/config/eventbuilder.ini
@@ -6,7 +6,7 @@ plugin_group_names = ['input', 'output']
 
 input =  'MongoDB.MongoDBReadUntriggered'
 decoder_plugin = 'MongoDB.MongoDBReadUntriggeredFiller'
-encoder_plugin = 'BSON.EncodeZBSON'
+encoder_plugin = 'Pickle.EncodeZPickle'
 output = ['Zip.WriteZipped',
           'MongoDB.MongoDBClearUntriggered']            # Clearuntriggered must be in output, it requires ordered events
 

--- a/pax/config/eventbuilder.ini
+++ b/pax/config/eventbuilder.ini
@@ -6,7 +6,7 @@ plugin_group_names = ['input', 'output']
 
 input =  'MongoDB.MongoDBReadUntriggered'
 decoder_plugin = 'MongoDB.MongoDBReadUntriggeredFiller'
-encoder_plugin = 'Pickle.EncodeZPickle'
+encoder_plugin = 'BSON.EncodeZBSON'
 output = ['Zip.WriteZipped',
           'MongoDB.MongoDBClearUntriggered']            # Clearuntriggered must be in output, it requires ordered events
 

--- a/pax/config/reduce_raw_data.ini
+++ b/pax/config/reduce_raw_data.ini
@@ -11,6 +11,6 @@ compute_properties = []
 pre_analysis = []
 pre_output = []
 
-; Output to the ZippedBSON format
-encoder_plugin = 'BSON.EncodeZBSON'
+; Output to the ZippedPicle format
+encoder_plugin = 'Pickle.EncodeZPickle'
 output = 'Zip.WriteZipped'

--- a/pax/plugins/io/MongoDB.py
+++ b/pax/plugins/io/MongoDB.py
@@ -82,7 +82,6 @@ class MongoBase:
         if not self.split_collections:
             self.input_collections = [db.get_collection(self.input_info['collection']) for db in self.dbs]
 
-
     def refresh_run_doc(self):
         """Update the internal run doc within this class
         (does not change anything in the runs database)

--- a/pax/plugins/io/MongoDB.py
+++ b/pax/plugins/io/MongoDB.py
@@ -52,7 +52,10 @@ class MongoBase:
             raise ValueError("Invalid run document: none of the 'data' entries contain untriggered data!")
 
         if ';' in self.input_info['location']:
+            self.split_hosts = True
             self.input_info['location'] = self.input_info['location'].split(';')[0]
+        else:
+            self.split_hosts = False
 
         self.input_info['database'] = self.input_info['location'].split('/')[-1]
         if not self.input_info['database'] == 'untriggered' and self.config['detector'] == 'tpc':
@@ -72,7 +75,6 @@ class MongoBase:
             self.input_collection = self.input_db.get_collection(self.input_info['collection'])
         # In split collections mode, we use the subcollection methods (see below) to get the input collections
 
-        self.split_hosts = self.run_doc['reader']['ini'].get('split_hosts', 0)
         if self.split_hosts:
             self.hosts = ['eb0', 'eb1', 'eb2']   # TODO: don't hardcode
         else:

--- a/pax/plugins/io/MongoDB.py
+++ b/pax/plugins/io/MongoDB.py
@@ -50,6 +50,10 @@ class MongoBase:
                 break
         else:
             raise ValueError("Invalid run document: none of the 'data' entries contain untriggered data!")
+
+        if ';' in self.input_info['location']:
+            self.input_info['location'] = self.input_info['location'].split(';')[0]
+
         self.input_info['database'] = self.input_info['location'].split('/')[-1]
         if not self.input_info['database'] == 'untriggered' and self.config['detector'] == 'tpc':
             raise ValueError("TPC data is expected in the 'untriggered' database,"

--- a/pax/plugins/io/MongoDB.py
+++ b/pax/plugins/io/MongoDB.py
@@ -298,7 +298,7 @@ class MongoDBReadUntriggered(plugin.InputPlugin, MongoBase):
             batches_to_search = min(batches_to_search, self.max_query_workers // len(self.hosts))
 
             # Start new queries in separate processes
-            with ThreadPoolExecutor(max_workers=batches_to_search) as executor:
+            with ThreadPoolExecutor(max_workers=self.max_query_workers) as executor:
                 futures = []
                 for batch_i in range(batches_to_search):
                     futures_per_host = []

--- a/pax/plugins/io/MongoDB.py
+++ b/pax/plugins/io/MongoDB.py
@@ -509,7 +509,7 @@ def get_pulses(client_maker_config, input_info, collection_name, query, get_area
     pymongo_client = client_maker.get_client(database_name=input_info['database'],
                                              uri=input_info['location'])
     coll = pymongo_client[input_info['database']].get_collection(collection_name)
-    coll.create_index([('time', 1), ('module', 1), ('channel', 1)], background=True)
+    coll.create_index([('time', 1), ('module', 1), ('channel', 1)])
 
     monary_client = client_maker.get_client(database_name=input_info['database'],
                                             uri=input_info['location'],

--- a/pax/plugins/io/MongoDB.py
+++ b/pax/plugins/io/MongoDB.py
@@ -6,7 +6,7 @@ either be triggered or untriggered. In the case of untriggered, an event builder
 must be run on the data and will result in triggered data.  Input and output
 classes are provided for MongoDB access.  More information is in the docstrings.
 """
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 from itertools import chain
 import time
 
@@ -298,7 +298,7 @@ class MongoDBReadUntriggered(plugin.InputPlugin, MongoBase):
             batches_to_search = min(batches_to_search, self.max_query_workers // len(self.hosts))
 
             # Start new queries in separate processes
-            with ProcessPoolExecutor(max_workers=self.max_query_workers) as executor:
+            with ThreadPoolExecutor(max_workers=self.max_query_workers) as executor:
                 futures = []
                 for batch_i in range(batches_to_search):
                     futures_per_host = []
@@ -528,7 +528,7 @@ class MongoDBClearUntriggered(plugin.TransformPlugin, MongoBase):
 
     def startup(self):
         MongoBase.startup(self)
-        self.executor = ProcessPoolExecutor(max_workers=self.config['max_query_workers'])
+        self.executor = ThreadPoolExecutor(max_workers=self.config['max_query_workers'])
 
     def transform_event(self, event_proxy):
         if not self.config['delete_data']:
@@ -593,7 +593,7 @@ def get_pulses(client_maker_config, input_info, collection_name, query, host, ge
     Returns four numpy arrays: times, modules, channels, areas.
     Areas consists of zeros unless get_area = True, in which we also fetch the 'integral' field.
 
-    The monary client is created inside this function, so we can run it with ProcessPoolExecutor.
+    The monary client is created inside this function, so we could run it with ProcessPoolExecutor.
     """
     client_maker = ClientMaker(client_maker_config)
 

--- a/pax/plugins/io/MongoDB.py
+++ b/pax/plugins/io/MongoDB.py
@@ -15,7 +15,7 @@ import numpy as np
 import pymongo
 import snappy
 
-from pax.MongoDB_ClientMaker import ClientMaker
+from pax.MongoDB_ClientMaker import ClientMaker, parse_passwordless_uri
 from pax.datastructure import Event, Pulse, EventProxy
 from pax import plugin, trigger, units
 
@@ -72,7 +72,7 @@ class MongoBase:
         if self.split_hosts:
             self.hosts = ['eb0', 'eb1', 'eb2']   # TODO: don't hardcode
         else:
-            self.hosts = [self.input_info['host']]
+            self.hosts = [parse_passwordless_uri(self.input_info['location'])[0]]
 
         # Make pymongo db handles for all hosts. Double work if not split_hosts, but avoids double code later
         self.dbs = [self.cm.get_client(database_name=self.input_info['database'],

--- a/pax/plugins/io/MongoDB.py
+++ b/pax/plugins/io/MongoDB.py
@@ -432,7 +432,7 @@ class MongoDBReadUntriggeredFiller(plugin.TransformPlugin, MongoBase):
         Does NOT deal with time ranges split between subcollections, but does deal with split hosts.
         """
         cursors = []
-        for host_i, host in self.hosts:
+        for host_i, host in enumerate(self.hosts):
             if subcollection_number is None:
                 assert not self.split_collections
                 collection = self.input_collections[host_i]

--- a/pax/plugins/io/MongoDB.py
+++ b/pax/plugins/io/MongoDB.py
@@ -603,8 +603,12 @@ def get_pulses(client_maker_config, input_info, collection_name, query, host, ge
                                             monary=True)
     fields = ['time', 'module', 'channel'] + (['integral'] if get_area else [])
     types = ['int64', 'int32', 'int32'] + (['area'] if get_area else [])
+
+    # Somehow monary's block query fails when we have multiple blocks,
+    # we need to take care of copying out the data ourselves, but even if I use .copy it doesn't seem to work
+    # Never mind, just make a big block
     results = list(monary_client.block_query(input_info['database'], collection_name, query, fields, types,
-                                             block_size=int(1e7),
+                                             block_size=int(5e8),
                                              select_fields=True))
     monary_client.close()
 

--- a/pax/plugins/io/MongoDB.py
+++ b/pax/plugins/io/MongoDB.py
@@ -6,7 +6,7 @@ either be triggered or untriggered. In the case of untriggered, an event builder
 must be run on the data and will result in triggered data.  Input and output
 classes are provided for MongoDB access.  More information is in the docstrings.
 """
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ProcessPoolExecutor
 from itertools import chain
 import time
 
@@ -298,7 +298,7 @@ class MongoDBReadUntriggered(plugin.InputPlugin, MongoBase):
             batches_to_search = min(batches_to_search, self.max_query_workers // len(self.hosts))
 
             # Start new queries in separate processes
-            with ThreadPoolExecutor(max_workers=self.max_query_workers) as executor:
+            with ProcessPoolExecutor(max_workers=self.max_query_workers) as executor:
                 futures = []
                 for batch_i in range(batches_to_search):
                     futures_per_host = []
@@ -528,7 +528,7 @@ class MongoDBClearUntriggered(plugin.TransformPlugin, MongoBase):
 
     def startup(self):
         MongoBase.startup(self)
-        self.executor = ThreadPoolExecutor(max_workers=self.config['max_query_workers'])
+        self.executor = ProcessPoolExecutor(max_workers=self.config['max_query_workers'])
 
     def transform_event(self, event_proxy):
         if not self.config['delete_data']:

--- a/pax/plugins/io/MongoDB.py
+++ b/pax/plugins/io/MongoDB.py
@@ -211,7 +211,7 @@ class MongoDBReadUntriggered(plugin.InputPlugin, MongoBase):
                             safe_col = min(v, safe_col)
                     safe_col -= 1
                     if safe_col < 0 or safe_col == float('inf'):
-                        print("No subcollection is safe for triggering yet")
+                        self.log.info("No subcollection is safe for triggering yet")
                         self.last_pulse_time = 0
                         return
                     self.latest_subcollection = safe_col

--- a/pax/plugins/io/MongoDB.py
+++ b/pax/plugins/io/MongoDB.py
@@ -35,6 +35,7 @@ class MongoBase:
         self.refresh_run_doc()
 
         self.split_collections = self.run_doc['reader']['ini'].get('rotating_collections', 0)
+
         if self.split_collections:
             self.batch_window = int(self.sample_duration * (2 ** 31))
             self.log.debug("Split collection mode: batch window forced to %s sec" % (self.batch_window / units.s))
@@ -60,10 +61,18 @@ class MongoBase:
                                                w=0)         # w=0 ensures fast deletes. We're not going to write.
         self.input_db = self.input_client[self.input_info['database']]
 
-        self.input_collection = self.input_db.get_collection(self.input_info['collection'])
+        if not self.split_collections:
+            self.input_collection = self.input_db.get_collection(self.input_info['collection'])
+        # In split collections mode, we use the subcollection methods (see below) to get the input collections
 
         start_datetime = self.run_doc['start'].replace(tzinfo=pytz.utc).timestamp()
         self.time_of_run_start = int(start_datetime * units.s)
+
+        self.split_hosts = self.run_doc['reader']['ini'].get('split_hosts', 0)
+        if self.split_hosts:
+            self.hosts = ['eb0', 'eb1', 'eb2']   # TODO: dont hardcode
+        else:
+            self.hosts = [self.input_info['host']]
 
     def refresh_run_doc(self):
         """Update the internal run doc within this class
@@ -173,7 +182,7 @@ class MongoDBReadUntriggered(plugin.InputPlugin, MongoBase):
                 # ahead of the insertion point.
                 if self.config.get('use_run_status_doc'):
                     # Dan made a doc with the approximate insertion point of each digitizer: the min of these should
-                    # be safe to use
+                    # be safe to use (more or less.. a slight delay is still advisable. ask Dan for details)
                     status_doc = self.input_db.get_collection('status').find_one({'collection': self.run_doc['name']})
                     if status_doc is None:
                         raise RuntimeError("Missing run status doc!")
@@ -267,32 +276,36 @@ class MongoDBReadUntriggered(plugin.InputPlugin, MongoBase):
                     self.log.info("DAQ has not taken sufficient data to continue. Sleeping 5 sec...")
                     time.sleep(5)
                     continue
-            batches_to_search = min(batches_to_search, self.max_query_workers)
+            batches_to_search = min(batches_to_search, self.max_query_workers // len(self.hosts))
 
             # Start new queries in separate processes
             with ThreadPoolExecutor(max_workers=batches_to_search) as executor:
                 futures = []
                 for batch_i in range(batches_to_search):
-                    start = next_time_to_search + batch_i * self.batch_window
-                    if self.split_collections:
-                        subcol_i = self.subcollection_with_time(next_time_to_search) + batch_i
-                        # Prep the query -- not a very difficult one :-)
-                        query = {}
-                        collection_name = self.subcollection_name(subcol_i)
-                        self.log.info("Submitting query for subcollection %d" % subcol_i)
-                    else:
-                        collection_name = self.run_doc['name']
-                        stop = start + self.batch_window
-                        query = self.time_range_query(start, stop)
-                        self.log.info("Submitting query for batch %d, time range [%s, %s)" % (
-                            batch_i, pax_to_human_time(start), pax_to_human_time(stop)))
-                    future = executor.submit(get_pulses,
-                                             client_maker_config=self.cm.config,
-                                             query=query,
-                                             input_info=self.input_info,
-                                             collection_name=collection_name,
-                                             get_area=self.config['can_get_area'])
-                    futures.append(future)
+                    futures_per_host = []
+                    for host in self.hosts:
+                        start = next_time_to_search + batch_i * self.batch_window
+                        if self.split_collections:
+                            subcol_i = self.subcollection_with_time(next_time_to_search) + batch_i
+                            # Prep the query -- not a very difficult one :-)
+                            query = {}
+                            collection_name = self.subcollection_name(subcol_i)
+                            self.log.info("Submitting query for subcollection %d" % subcol_i)
+                        else:
+                            collection_name = self.run_doc['name']
+                            stop = start + self.batch_window
+                            query = self.time_range_query(start, stop)
+                            self.log.info("Submitting query for batch %d, time range [%s, %s)" % (
+                                batch_i, pax_to_human_time(start), pax_to_human_time(stop)))
+                        future = executor.submit(get_pulses,
+                                                 client_maker_config=self.cm.config,
+                                                 query=query,
+                                                 input_info=self.input_info,
+                                                 collection_name=collection_name,
+                                                 host=host,
+                                                 get_area=self.config['can_get_area'])
+                        futures_per_host.append(future)
+                    futures.append(futures_per_host)
 
                 # Record advancement of the batch window
                 last_time_searched = next_time_to_search + batches_to_search * self.batch_window
@@ -313,8 +326,34 @@ class MongoDBReadUntriggered(plugin.InputPlugin, MongoBase):
                         more_data_coming = False
 
                 # Retrieve results from the queries, then build events (which must happen serially).
-                for i, future in enumerate(futures):
-                    times, modules, channels, areas = future.result()
+                for i, futures_per_host in enumerate(futures):
+                    if len(futures_per_host) == 1:
+                        assert not self.split_hosts
+                        times, modules, channels, areas = futures_per_host[0].result()
+                    else:
+                        assert self.split_hosts
+                        times = []
+                        modules = []
+                        channels = []
+                        areas = []
+                        for f in futures_per_host:
+                            ts, ms, chs, ars = f.result()
+                            times.append(ts)
+                            modules.append(ms)
+                            channels.append(chs)
+                            areas.append(ars)
+                        times = np.concatenate(times)
+                        modules = np.concatenate(modules)
+                        channels = np.concatenate(channels)
+                        areas = np.concatenate(areas)
+
+                    # Sort the results
+                    sort_order = np.argsort(times)
+                    times = times[sort_order]
+                    modules = modules[sort_order]
+                    channels = channels[sort_order]
+                    areas = areas[sort_order]
+
                     times = times * self.sample_duration
 
                     if len(times):
@@ -370,17 +409,23 @@ class MongoDBReadUntriggeredFiller(plugin.TransformPlugin, MongoBase):
                               x['digitizer']['channel']): x['pmt_position'] for x in self.pmts}
 
     def _get_cursor_between_times(self, start, stop, subcollection_number=None):
-        """Returns a cursor over all pulses that start in [start, stop) (both pax units since start of run),
-        sorted by start time.
-        Does NOT deal with time ranges split between subcollections!!
+        """Returns a cursor over all pulses that start in [start, stop) (both pax units since start of run).
+        Order is not defined.
+        Does NOT deal with time ranges split between subcollections, but does deal with split hosts.
         """
-        if subcollection_number is None:
-            assert not self.split_collections
-            collection = self.input_collection
+        cursors = []
+        for host in self.hosts:
+            if subcollection_number is None:
+                assert not self.split_collections
+                collection = self.input_collection
+            else:
+                assert self.split_collections
+                collection = self.subcollection(subcollection_number)
+            cursors.append(collection.find(self.time_range_query(start, stop)))
+        if len(self.hosts) == 1:
+            return cursors[0]
         else:
-            assert self.split_collections
-            collection = self.subcollection(subcollection_number)
-        return collection.find(self.time_range_query(start, stop), sort=[('time', 1)])
+            return chain(*cursors)
 
     def transform_event(self, event_proxy):
         # t0, t1 are the start, stop time of the event in pax units (ns) since the start of the run
@@ -440,7 +485,6 @@ class MongoDBReadUntriggeredFiller(plugin.TransformPlugin, MongoBase):
 
 
 class MongoDBClearUntriggered(plugin.TransformPlugin, MongoBase):
-
     """Clears data whose events have been built from MongoDB>
     Will do NOTHING unless delete_data = True in config.
     This must run as part of the output group, so it gets the events in order.
@@ -463,6 +507,13 @@ class MongoDBClearUntriggered(plugin.TransformPlugin, MongoBase):
         MongoBase.startup(self)
         self.executor = ThreadPoolExecutor(max_workers=self.config['max_query_workers'])
 
+        # We need pymongo db handles for all hosts
+        # w=0 ensures fast deletes. We're not going to write.
+        self.dbs = [self.cm.get_client(database_name=self.input_info['database'],
+                                       host=host,
+                                       uri=self.input_info['location'],
+                                       w=0)[self.input_info['database']] for host in self.hosts]
+
     def transform_event(self, event_proxy):
         if not self.config['delete_data']:
             return event_proxy
@@ -473,17 +524,19 @@ class MongoDBClearUntriggered(plugin.TransformPlugin, MongoBase):
             while coll_number > self.last_subcollection_not_yet_deleted:
                 self.log.info("Seen event at subcollection %d, clearing subcollection %d" % (
                     coll_number, self.last_subcollection_not_yet_deleted))
-                self.executor.submit(self.input_db.drop_collection,
-                                     self.subcollection_name(self.last_subcollection_not_yet_deleted))
+                for db in self.dbs:
+                    self.executor.submit(db.drop_collection,
+                                         self.subcollection_name(self.last_subcollection_not_yet_deleted))
                 self.last_subcollection_not_yet_deleted += 1
         else:
             if time_since_start > self.last_time_deleted + self.config['batch_window']:
                 self.log.info("Seen event at %s, clearing "
                               "all data until then." % pax_to_human_time(time_since_start))
-                self.executor.submit(delete_pulses,
-                                     self.input_collection,
-                                     start_mongo_time=self._to_mt(self.last_time_deleted),
-                                     stop_mongo_time=self._to_mt(time_since_start))
+                for db in self.dbs:
+                    self.executor.submit(delete_pulses,
+                                         db.get_collection(self.run_doc['name']),  # TODO nasty duplication!
+                                         start_mongo_time=self._to_mt(self.last_time_deleted),
+                                         stop_mongo_time=self._to_mt(time_since_start))
                 self.last_time_deleted = time_since_start
 
         return event_proxy
@@ -493,11 +546,13 @@ class MongoDBClearUntriggered(plugin.TransformPlugin, MongoBase):
             return
 
         # Clear all (sub)collections for this run
+        # TODO: should we scan remaining collections on all hosts?
         self.log.info("Dropping all remaining collections")
         for coll_name in self.input_db.collection_names():
             if not coll_name.startswith(self.run_doc['name']):
                 continue
-            self.input_db.drop_collection(coll_name)
+            for db in self.dbs:
+                db.drop_collection(coll_name)
         self.log.info("Completed.")
 
         # Update the run doc to remove the 'untriggered' entry
@@ -516,7 +571,7 @@ def pax_to_human_time(num):
     return "%3.1f %s" % (num, 's')
 
 
-def get_pulses(client_maker_config, input_info, collection_name, query, get_area=False):
+def get_pulses(client_maker_config, input_info, collection_name, query, host, get_area=False):
     """Find pulse times according to query using monary.
     Returns four numpy arrays: times, modules, channels, areas.
     Areas consists of zeros unless get_area = True, in which we also fetch the 'integral' field.
@@ -525,23 +580,9 @@ def get_pulses(client_maker_config, input_info, collection_name, query, get_area
     """
     client_maker = ClientMaker(client_maker_config)
 
-    # Start building the index. If we only did this query, we might not really need it, but since
-    # we need at least a timestamp index later anyway for the filler, might as well create it now.
-    pymongo_client = client_maker.get_client(database_name=input_info['database'],
-                                             uri=input_info['location'])
-    coll = pymongo_client[input_info['database']].get_collection(collection_name)
-    coll.create_index([('time', 1), ('module', 1), ('channel', 1)], background=True)
-
-    # Sleep a bit to allow the background index creation to finish..
-    while True:
-        time.sleep(5)
-        indices = list(coll.list_indexes())
-        if len(indices):
-            print("Indices %s found in %s, submitting monary query" % (str(indices), collection_name))
-            break
-
     monary_client = client_maker.get_client(database_name=input_info['database'],
                                             uri=input_info['location'],
+                                            host=host,
                                             monary=True)
     fields = ['time', 'module', 'channel'] + (['integral'] if get_area else [])
     types = ['int64', 'int32', 'int32'] + (['area'] if get_area else [])
@@ -567,13 +608,6 @@ def get_pulses(client_maker_config, input_info, collection_name, query, get_area
         else:
             times, modules, channels = results
             areas = np.zeros(len(times), dtype=np.float64)
-
-        # Sort ourselves, to spare Mongo the trouble
-        sort_order = np.argsort(times)
-        times = times[sort_order]
-        modules = modules[sort_order]
-        channels = channels[sort_order]
-        areas = areas[sort_order]
 
     return times, modules, channels, areas
 

--- a/pax/trigger_plugins/DeadTimeTally.py
+++ b/pax/trigger_plugins/DeadTimeTally.py
@@ -58,7 +58,7 @@ class DeadTimeTally(TriggerPlugin):
 
         for t in special_times:
 
-            while t > self.next_save_time:
+            while t['time'] > self.next_save_time:
                 self.save_monitor_data()
                 self.next_save_time += self.save_interval
 

--- a/pax/trigger_plugins/DeadTimeTally.py
+++ b/pax/trigger_plugins/DeadTimeTally.py
@@ -69,8 +69,8 @@ class DeadTimeTally(TriggerPlugin):
                 if ch_info['means_on']:
                     # Happens very often, not going to emit a warning all the time
                     # TODO: emit it once, then shut up.
-                    self.log.debug("%s-on signal received while system was already active!\n"
-                                   "The signal has been ignored." % system_name)
+                    self.log.warning("%s-on signal received while system was already active!\n"
+                                     "The signal has been ignored." % system_name)
                 else:
                     # System has turned off
                     system['active'] = False
@@ -83,8 +83,8 @@ class DeadTimeTally(TriggerPlugin):
                     system['start_of_current_dead_time'] = t['time']
                     pass
                 else:
-                    self.log.info("%s-off signal received while system was not yet active!\n"
-                                  "The signal has been ignored." % system_name)
+                    self.log.warning("%s-off signal received while system was not yet active!\n"
+                                     "The signal has been ignored." % system_name)
                     pass
 
         if data.last_data:

--- a/pax/trigger_plugins/DeadTimeTally.py
+++ b/pax/trigger_plugins/DeadTimeTally.py
@@ -45,7 +45,7 @@ class DeadTimeTally(TriggerPlugin):
                 system['dead_time_tally'] += self.next_save_time - system['start_of_current_dead_time']
                 system['start_of_current_dead_time'] = self.next_save_time
 
-            dead_times[system_name] = system['dead_time_tally']
+            dead_times[system_name] = int(system['dead_time_tally'])   # numpy int crap
             system['dead_time_tally'] = 0
 
         self.trigger.save_monitor_data('dead_time_info', dead_times)

--- a/pax/trigger_plugins/DeadTimeTally.py
+++ b/pax/trigger_plugins/DeadTimeTally.py
@@ -67,8 +67,10 @@ class DeadTimeTally(TriggerPlugin):
             system = self.systems[system_name]
             if system['active']:
                 if ch_info['means_on']:
-                    self.log.warning("%s-on signal received while system was already active!\n"
-                                     "The signal has been ignored." % system_name)
+                    # Happens very often, not going to emit a warning all the time
+                    # TODO: emit it once, then shut up.
+                    self.log.debug("%s-on signal received while system was already active!\n"
+                                   "The signal has been ignored." % system_name)
                 else:
                     # System has turned off
                     system['active'] = False
@@ -81,8 +83,8 @@ class DeadTimeTally(TriggerPlugin):
                     system['start_of_current_dead_time'] = t['time']
                     pass
                 else:
-                    self.log.warning("%s-off signal received while system was not yet active!\n"
-                                     "The signal has been ignored." % system_name)
+                    self.log.info("%s-off signal received while system was not yet active!\n"
+                                  "The signal has been ignored." % system_name)
                     pass
 
         if data.last_data:
@@ -92,3 +94,5 @@ class DeadTimeTally(TriggerPlugin):
             while data.last_time_searched > self.next_save_time:
                 self.save_monitor_data()
                 self.next_save_time += self.save_interval
+
+        self.log.info("Done calculating dead time for this batch")

--- a/pax/trigger_plugins/DeadTimeTally.py
+++ b/pax/trigger_plugins/DeadTimeTally.py
@@ -53,7 +53,7 @@ class DeadTimeTally(TriggerPlugin):
     def process(self, data):
         self.next_save_time = self.config['dark_rate_save_interval']
         self.save_interval = self.config['dark_rate_save_interval']
-        special_times = data.times[np.in1d(data.times['pmt'], self.special_channels.keys())]
+        special_times = data.times[np.in1d(data.times['pmt'], list(self.special_channels.keys()))]
         self.log.info("Found %d signal in on/off acquisition monitor channels" % len(special_times))
 
         for t in special_times:


### PR DESCRIPTION
This upgrades the eventbuilder to deal with the new MongoDB setup (split hosts), and changes the raw data format to one that is 2x faster to create for the trigger (which means our top speed is much improved). The format is now gzip-compressed pickles rather than gzip-compressed bsons. 

Until this is merged and the pax on midway is updated, we won't be able to process the data we're taking. We will be able to reprocess old data after the merge, I've updated the run docs for old runs (<1933) to tell pax to expect the old output format. 