### PR TITLE
Reformat trigger data to use list

### DIFF
--- a/pax/config/reduce_raw_data.ini
+++ b/pax/config/reduce_raw_data.ini
@@ -2,8 +2,6 @@
 ; the --event_numbers_file switch to reduce raw data files
 
 [pax]
-parent_configuration = 'XENON100'
-
 ;  don't process, just reduce data
 dsp = []
 transform = []

--- a/pax/trigger.py
+++ b/pax/trigger.py
@@ -248,13 +248,8 @@ class Trigger(object):
           data_type: string indicating what kind of data this is (e.g. count_of_lone_pulses).
           data: either
             a dictionary with things bson.BSON.encode() will not crash on, or
-<<<<<<< HEAD
             a numpy array. It will be converted to a list, to ensure it is queryable by the DAQ website.
-          metadata: more data. Just convenience so you can pass numpy array as data.
-=======
-            a numpy array. I'll convert it to bytes on the fly because I am just a nice guy.
           metadata: more data. Just convenience so you can pass numpy array as data, then something else as well.
->>>>>>> refs/remotes/origin/master
         """
         if isinstance(data, np.ndarray):
             data = {'data': data.tolist()}

--- a/pax/trigger.py
+++ b/pax/trigger.py
@@ -115,6 +115,7 @@ class Trigger(object):
 
         self.end_of_run_info = dict(pulses_read=0,
                                     signals_found=0,
+                                    trigger_monitor_data_format_version=2,
                                     events_built=0,
                                     start_timestamp=time.time(),
                                     pax_version=pax.__version__,
@@ -233,7 +234,7 @@ class Trigger(object):
           data_type: string indicating what kind of data this is (e.g. count_of_lone_pulses).
           data: either
             a dictionary with things bson.BSON.encode() will not crash on, or
-            a numpy array. I'll convert it to bytes on the fly because I am just a nice guy.
+            a numpy array. It will be converted to a list, to ensure it is queryable by the DAQ website.
           metadata: more data. Just convenience so you can pass numpy array as data.
         """
         if isinstance(data, np.ndarray):

--- a/pax/trigger.py
+++ b/pax/trigger.py
@@ -237,7 +237,7 @@ class Trigger(object):
           metadata: more data. Just convenience so you can pass numpy array as data.
         """
         if isinstance(data, np.ndarray):
-            data = {'data': bson.Binary(data.tostring())}
+            data = {'data': data.tolist()}
         data['data_type'] = data_type
         if metadata is not None:
             data.update(metadata)


### PR DESCRIPTION
It would make the trigger monitor frontend much easier if we implement this change. The idea is to save trigger data as arrays, which can be queried and manipulated in the aggregation pipeline and not as compressed ndarrays, which generally have to be fully unpacked before they are useful.

A side effect is that the format will change for trigger monitor data stored offline. We will have to put a small update to hax to test what the format is so it can read properly.