### PR TITLE
Small speed improvements for the event builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,24 +14,24 @@ matrix:
           env: PYTHON=2.7 ROOT=6.04
         - python: 3.4
           env: PYTHON=3.4 ROOT=6.04
-        - language: generic
-          os: osx
-          osx_image: xcode6.4
-          env: PYTHON=2.7 ROOT=5.34.32
-        - language: generic
-          os: osx
-          osx_image: xcode6.4
-          env: PYTHON=2.7 ROOT=6.04
-        - language: generic
-          os: osx
-          osx_image: xcode6.4
-          env: PYTHON=3.4 ROOT=5.34.32
-        - language: generic
-          os: osx
-          osx_image: xcode6.4
-          env: PYTHON=3.4 ROOT=6.04
-    allow_failures:
-        - os: osx
+    #     - language: generic
+    #       os: osx
+    #       osx_image: xcode6.4
+    #       env: PYTHON=2.7 ROOT=5.34.32
+    #     - language: generic
+    #       os: osx
+    #       osx_image: xcode6.4
+    #       env: PYTHON=2.7 ROOT=6.04
+    #     - language: generic
+    #       os: osx
+    #       osx_image: xcode6.4
+    #       env: PYTHON=3.4 ROOT=5.34.32
+    #     - language: generic
+    #       os: osx
+    #       osx_image: xcode6.4
+    #       env: PYTHON=3.4 ROOT=6.04
+    # allow_failures:
+    #     - os: osx
 
 
 notifications:

--- a/bin/event-builder
+++ b/bin/event-builder
@@ -147,7 +147,7 @@ def main():
         for argname in ('detector', 'secret_mode',
                         'host', 'port', 'user', 'password',
                         'batch_window', 'delete_data', 'edge_safety_margin',
-                        'max_query_workers', 'skip_ahead', 'stop_after_sec', 'start_from_sec'):
+                        'max_query_workers', 'skip_ahead', 'stop_after_sec', 'start_after_sec'):
             argval = getattr(args, argname)
             if argval is None or argval == '':
                 continue

--- a/bin/event-builder
+++ b/bin/event-builder
@@ -41,10 +41,12 @@ def main():
     log = setup_logging(loglevel=args.log.upper())
 
     # Check for strange argument combinations
-    if args.stop_after_sec and (0 < args.stop_after_sec < float('inf')) and not args.secret_mode:
-        print("You are about to stop the trigger after %d sec of data in the run, which means you are probably testing "
+    not_searching_full_run = ((args.stop_after_sec and (0 < args.stop_after_sec < float('inf'))) or
+                              (args.start_after_sec and (0 < args.start_after_sec < float('inf'))))
+    if not_searching_full_run and not args.secret_mode:
+        print("You are about to trigger on a piece of a run, which means you are probably testing "
               "something out. However, you have NOT enabled secret mode and will be writing to official runs db!\n"
-              "Are you sure??" % args.stop_after_sec)
+              "Are you sure??")
         if input().lower() not in ('y', 'yes'):
             print("\nFine, Exiting event builder...\n")
             exit()
@@ -145,7 +147,7 @@ def main():
         for argname in ('detector', 'secret_mode',
                         'host', 'port', 'user', 'password',
                         'batch_window', 'delete_data', 'edge_safety_margin',
-                        'max_query_workers', 'skip_ahead', 'stop_after_sec'):
+                        'max_query_workers', 'skip_ahead', 'stop_after_sec', 'start_from_sec'):
             argval = getattr(args, argname)
             if argval is None or argval == '':
                 continue
@@ -390,7 +392,10 @@ def get_command_line_arguments():
                                         "Use only for dealing quickly with runs that have overflown to disk!")
     mongoreader_group.add_argument('--stop_after_sec', type=float,
                                    help="Stop the trigger after this many seconds of data have been read. "
-                                        "Won't stop in the middle of a batch. Use only for testing!")
+                                        "Will round to query batch. Use only for testing!")
+    mongoreader_group.add_argument('--start_after_sec', type=float,
+                                   help="Start the trigger after this many seconds into the run. "
+                                        "Use only for testing!")
 
     args = parser.parse_args()
     return args

--- a/pax/FolderIO.py
+++ b/pax/FolderIO.py
@@ -8,7 +8,6 @@ import shutil
 from operator import itemgetter
 
 from bson import json_util
-import snappy
 
 from six.moves import input
 from pax import utils, plugin
@@ -315,10 +314,7 @@ class ReadZippedDecoder(plugin.TransformPlugin):
     do_input_check = False
 
     def transform_event(self, event_proxy):
-        if self.config.get('compression_format') == 'snappy':
-            data = snappy.decompress(event_proxy.data)
-        else:
-            data = zlib.decompress(event_proxy.data)
+        data = zlib.decompress(event_proxy.data)
         return self.decode_event(data)
 
     def decode_event(self, event):
@@ -337,10 +333,7 @@ class WriteZippedEncoder(plugin.TransformPlugin):
     def transform_event(self, event):
         event_number = event.event_number
         data = self.encode_event(event)
-        if self.config.get('compression_format') == 'snappy':
-            data = snappy.compress(data)
-        else:
-            data = zlib.compress(data, self.compresslevel)
+        data = zlib.compress(data, self.compresslevel)
         # Add start and stop time to the data, for use in MongoDBClearUntriggered
         return EventProxy(data=dict(blob=data,
                                     start_time=event.start_time,

--- a/pax/FolderIO.py
+++ b/pax/FolderIO.py
@@ -8,6 +8,7 @@ import shutil
 from operator import itemgetter
 
 from bson import json_util
+import snappy
 
 from six.moves import input
 from pax import utils, plugin
@@ -314,7 +315,10 @@ class ReadZippedDecoder(plugin.TransformPlugin):
     do_input_check = False
 
     def transform_event(self, event_proxy):
-        data = zlib.decompress(event_proxy.data)
+        if self.config.get('compression_format') == 'snappy':
+            data = snappy.decompress(event_proxy.data)
+        else:
+            data = zlib.decompress(event_proxy.data)
         return self.decode_event(data)
 
     def decode_event(self, event):
@@ -333,7 +337,10 @@ class WriteZippedEncoder(plugin.TransformPlugin):
     def transform_event(self, event):
         event_number = event.event_number
         data = self.encode_event(event)
-        data = zlib.compress(data, self.compresslevel)
+        if self.config.get('compression_format') == 'snappy':
+            data = snappy.compress(data)
+        else:
+            data = zlib.compress(data, self.compresslevel)
         # Add start and stop time to the data, for use in MongoDBClearUntriggered
         return EventProxy(data=dict(blob=data,
                                     start_time=event.start_time,

--- a/pax/config/_base.ini
+++ b/pax/config/_base.ini
@@ -302,7 +302,8 @@ fields_to_ignore = ['sum_waveforms',
                    ]
 
 [Zip]
-events_per_file = 1000
+events_per_file = 250
+compression_format = 'snappy'
 
 [BSON]
 # By default, BSON-type formats are used for raw data

--- a/pax/config/_base.ini
+++ b/pax/config/_base.ini
@@ -304,8 +304,6 @@ fields_to_ignore = ['sum_waveforms',
 [Zip]
 events_per_file = 250
 
-[Pickle]
-compression_format = 'snappy'
 
 [BSON]
 # By default, BSON-type formats are used for raw data

--- a/pax/config/_base.ini
+++ b/pax/config/_base.ini
@@ -303,6 +303,8 @@ fields_to_ignore = ['sum_waveforms',
 
 [Zip]
 events_per_file = 250
+
+[Pickle]
 compression_format = 'snappy'
 
 [BSON]

--- a/pax/data_model.py
+++ b/pax/data_model.py
@@ -30,6 +30,7 @@ class Model(object):
             # Speed is critical! Forget about any syntax sugar, just set the attributes from kwargs
             for k, v in kwargs.items():
                 setattr(self, k, v)
+            return
 
         # Initialize the collection fields to empty lists
         # object.__setattr__ is needed to bypass type checking in StrictModel

--- a/pax/data_model.py
+++ b/pax/data_model.py
@@ -25,7 +25,12 @@ class Model(object):
       - dump as dictionary and JSON
     """
 
-    def __init__(self, kwargs_dict=None, **kwargs):
+    def __init__(self, kwargs_dict=None, do_it_fast=False, **kwargs):
+        if do_it_fast:
+            # Speed is critical! Forget about any syntax sugar, just set the attributes from kwargs
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
         # Initialize the collection fields to empty lists
         # object.__setattr__ is needed to bypass type checking in StrictModel
         list_field_info = self.get_list_field_info()

--- a/pax/datastructure.py
+++ b/pax/datastructure.py
@@ -12,7 +12,7 @@ import numpy as np
 import six
 
 from pax import units
-from pax.data_model import StrictModel, ListField
+from pax.data_model import Model, StrictModel, ListField
 if six.PY3:
     long = int
 
@@ -393,7 +393,7 @@ class SumWaveform(StrictModel):
             return False
 
 
-class Pulse(StrictModel):
+class Pulse(Model):
     """A region of raw digitizer data.
     For DAQs with zero-length encoding or self-triggering, there will be several of these per channel per event.
 
@@ -450,7 +450,7 @@ class Pulse(StrictModel):
          - raw_data (numpy array of samples)
          - right (last index)
         """
-        StrictModel.__init__(self, **kwargs)
+        Model.__init__(self, **kwargs)
 
         if self.channel == INT_NAN:
             raise ValueError("Must specify channel to init Pulse")

--- a/pax/plugins/ZLE.py
+++ b/pax/plugins/ZLE.py
@@ -110,10 +110,13 @@ class SoftwareZLE(plugin.TransformPlugin):
                     if self.debug:
                         plt.axvspan(start, stop, alpha=0.3, color='green')
 
+                    # Explicit casts necessary since we've disabled type checking for pulse class
+                    # for speed in event builder.
+                    # and otherwise numpy ints would get in and break e.g. BSON output.
                     new_pulses.append(datastructure.Pulse(
-                        channel=pulse.channel,
-                        left=pulse.left+start,
-                        right=pulse.left+stop,
+                        channel=int(pulse.channel),
+                        left=int(pulse.left+start),
+                        right=int(pulse.left+stop),
                         raw_data=pulse.raw_data[start:stop + 1]
                     ))
                     itvs_encoded += 1

--- a/pax/plugins/io/MongoDB.py
+++ b/pax/plugins/io/MongoDB.py
@@ -186,9 +186,10 @@ class MongoDBReadUntriggered(plugin.InputPlugin, MongoBase):
                                        trigger_monitor_collection=trig_mon_coll)
 
         # For starting event building in the middle of a run:
-        self.initial_start_time = self.config.get('start_after_sec', 0)
+        self.initial_start_time = self.config.get('start_after_sec', 0) * units.s
         if self.initial_start_time:
             self.latest_subcollection = self.initial_start_time // self.batch_window
+            self.log.info("Starting at %0.1f sec, subcollection %d" % (self.initial_start_time, self.latest_subcollection))
 
     def refresh_run_info(self):
         """Refreshes the run doc and last pulse time information.
@@ -254,7 +255,7 @@ class MongoDBReadUntriggered(plugin.InputPlugin, MongoBase):
                 if not self.latest_subcollection == 0:
                     self.log.warning("Latest subcollection %d seems empty now, but wasn't before... Race condition/edge"
                                      " case in mongodb, bug in clearing code, or something else weird? Investigate if "
-                                     "this occurs often!!")
+                                     "this occurs often!!" % self.latest_subcollection)
                 last_pulse_time = self.latest_subcollection * self.batch_window
             else:
                 # Apparently the DAQ has not taken any pulses yet?
@@ -280,6 +281,7 @@ class MongoDBReadUntriggered(plugin.InputPlugin, MongoBase):
         self.refresh_run_info()
         # Last time (ns) searched, exclusive. ie we searched [something, last_time_searched)
         last_time_searched = self.initial_start_time
+        self.log.info("self.initial_start_time: %s", pax_to_human_time(self.initial_start_time))
         next_event_number = 0
         more_data_coming = True
 

--- a/pax/plugins/io/MongoDB.py
+++ b/pax/plugins/io/MongoDB.py
@@ -189,7 +189,8 @@ class MongoDBReadUntriggered(plugin.InputPlugin, MongoBase):
         self.initial_start_time = self.config.get('start_after_sec', 0) * units.s
         if self.initial_start_time:
             self.latest_subcollection = self.initial_start_time // self.batch_window
-            self.log.info("Starting at %0.1f sec, subcollection %d" % (self.initial_start_time, self.latest_subcollection))
+            self.log.info("Starting at %0.1f sec, subcollection %d" % (self.initial_start_time,
+                                                                       self.latest_subcollection))
 
     def refresh_run_info(self):
         """Refreshes the run doc and last pulse time information.

--- a/pax/plugins/io/MongoDB.py
+++ b/pax/plugins/io/MongoDB.py
@@ -467,7 +467,11 @@ class MongoDBReadUntriggeredFiller(plugin.TransformPlugin, MongoBase):
                 assert self.split_collections
                 collection = self.subcollection(subcollection_number, host_i)
             query = self.time_range_query(start, stop)
-            cursors.append(collection.find(query))
+            cursor = collection.find(query)
+            # Ask for a large batch size: the default is 101 documents or 1MB. This results in a very small speed
+            # increase (when I measured it on a normal dataset)
+            cursor.batch_size(int(1e7))
+            cursors.append(cursor)
             if self.max_pulses_per_event != float('inf'):
                 count += collection.count(query)
         if len(self.hosts) == 1:

--- a/pax/plugins/io/XED.py
+++ b/pax/plugins/io/XED.py
@@ -210,7 +210,7 @@ class DecodeXED(plugin.TransformPlugin):
             data = np.reshape(data, (metadata['channels'], metadata['samples_in_event']))
             for ch_i, chdata in enumerate(data):
                 event.pulses.append(Pulse(
-                    channel=ch_i + 1,       # +1 as first channel is 1 in Xenon100
+                    channel=int(ch_i + 1),       # +1 as first channel is 1 in Xenon100
                     left=0,
                     raw_data=chdata
                 ))
@@ -261,8 +261,8 @@ class DecodeXED(plugin.TransformPlugin):
                                                       dtype="<i2")
 
                         event.pulses.append(Pulse(
-                            channel=channel_id,
-                            left=sample_position,
+                            channel=int(channel_id),
+                            left=int(sample_position),
                             raw_data=samples_pulse
                         ))
 

--- a/pax/plugins/signal_processing/CheckPulses.py
+++ b/pax/plugins/signal_processing/CheckPulses.py
@@ -123,9 +123,11 @@ class CheckBoundsAndCount(plugin.TransformPlugin):
                     end_index = event_length - 1
 
                 # Update the pulse data, so hit finder won't look at old un-truncated pulse
-                event.pulses[pulse_i] = datastructure.Pulse(left=start_index,
-                                                            right=end_index,
-                                                            channel=channel,
+                # Explicit casts necessary since we've disabled type checking for pulse class for speed in event builder
+                # and otherwise numpy ints would get in and break e.g. BSON output
+                event.pulses[pulse_i] = datastructure.Pulse(left=int(start_index),
+                                                            right=int(end_index),
+                                                            channel=int(channel),
                                                             raw_data=pulse_wave)
 
         # Remove the to-be-ignored-pulses


### PR DESCRIPTION
This slightly improves the speed of the event builder by:

* Dropping the continuous type checking on the pulse class (StrictModel->Model). A few other places in the code had to be updated to provide nice vanilla python types (and not numpy types that would break BSON encoding).
* Add a `do_it_fast=True` option for Model.__init__ that bypasses some of the extra features we use for conveniently serializing entire events. This is only activated when initializing pulses in the event builder.
* Increase the default pymongo batch size, avoiding extra round trips to the database.

This also includes a command line option for starting event building in the middle of a run. You get warning and a confirmation prompt if you use this outside secret mode (as for stopping in the middle of a run).

I tested it on a dataset with a bit of Rn220 in it; this improves the speed increases the speed by ~24%. We could improve it more by changing the compression from pickle to snappy, but this would result in a marginal gain while increasing the file size by 50%. 