### PR TITLE
Compute saturation correction even if not included in total

### DIFF
--- a/pax/config/XENON100.ini
+++ b/pax/config/XENON100.ini
@@ -166,18 +166,19 @@ s2_pairing_threshold = 70  # pe
 
 
 [BuildInteractions.BasicInteractionProperties]
+include_saturation_correction = True
+
 # Add 'zombie PMTS' here
-# To turn off set active_saturation_and_zombie_correction = False
 # These are PMTs who have died, but the loss of light yield has not yet been accounted for in the overall S1 or S2
 # light yield map. These PMTs will be treated just like saturated PMTs: when computing the corrected area,
 # the observed area in the zombie channels (which will be 0) is replaced by the expected area based on the other PMTs.
 # DO NOT keep PMTs here after the light yield maps have been fixed!!!
 # If you don't understand why, stop modifying the file and just fix the light yield map!
-active_saturation_and_zombie_correction = True
 zombie_pmts_s1 = []
+
 # S2 zombie PMTs will only work on the top, as we have no S2(x,y,pmt) patterns for the bottom array.
 # For now, all dead top PMTs are included for the S2, since we don't have the S2(x, y) light yield in pax yet...
-zombie_pmts_s2 = [] #[9, 12, 39, 58]
+zombie_pmts_s2 = []  #[9, 12, 39, 58]
 
 
 [RobustWeightedMean.PosRecRobustWeightedMean]

--- a/pax/config/XENON1T.ini
+++ b/pax/config/XENON1T.ini
@@ -39,12 +39,16 @@ dsp = [
 
 # Compute peak properties: can be redone from processed data file
 compute_properties = [
+                        # Position reconstruction
                         'WeightedSum.PosRecWeightedSum',
                         'MaxPMT.PosRecMaxPMT',
                         'RobustWeightedMean.PosRecRobustWeightedMean',
                         'NeuralNet.PosRecNeuralNet',
                         'TopPatternFit.PosRecTopPatternFit',
+
+                        # Additional properties
                         'HitpatternSpread.HitpatternSpread',
+                        'PeakAreaCorrections.S2SaturationCorrection',
                      ]
 
 # Final stage with 'risky' operations: peak classification, S1/S2 pairing, corrections
@@ -322,9 +326,6 @@ pair_n_s1s = 3
 # Never pair S2s smaller than:
 s2_pairing_threshold = 70  # pe
 
-# Preference in algorithms to use for the xy reconstructed position
-xy_posrec_preference = ['PosRecTopPatternFit', 'PosRecNeuralNet', 'PosRecWeightedSum']
-
 
 [RobustWeightedMean.PosRecRobustWeightedMean]
 # Remove PMTs that are more than ... away in each step
@@ -378,6 +379,10 @@ tpc_radius =                    47.9 * cm          # Monte Carlo paper draft, li
 
 electron_lifetime_liquid =      450 * us           # PLACEHOLDER: from XENON100
 drift_velocity_liquid =         1.48 * um / ns     # Cathode at 15 kV, see xenon:xenon1t:aalbers:first_full_drift_events
+
+# Preference in algorithms to use for the xy reconstructed position
+# Used in BuildInteractions and PeakAreaCorrections
+xy_posrec_preference = ['PosRecTopPatternFit', 'PosRecNeuralNet', 'PosRecWeightedSum']
 
 channels_in_detector = {
     'tpc':   list(range(0,   247+1)),

--- a/pax/config/_base.ini
+++ b/pax/config/_base.ini
@@ -76,8 +76,10 @@ subtract_reference_baseline_only_for_raw_waveform = False
 # Statistic to use for the S1 pattern goodness of fit: same options as for PosRecTopPatternFit
 s1_pattern_statistic = 'likelihood_poisson'
 
-# Set this to true to activate corrections for S1 and S2 saturation & zombie PMTs
-active_saturation_and_zombie_correction = False
+# Set this to true to include corrections for S1 and S2 saturation & zombie PMTs
+# If false, the saturation corrections will still be computed, but it will not be taken into account in the final
+# total correction.
+include_saturation_correction = False
 
 
 ##

--- a/pax/plugins/interaction_processing/BuildInteractions.py
+++ b/pax/plugins/interaction_processing/BuildInteractions.py
@@ -102,7 +102,7 @@ class BasicInteractionProperties(plugin.TransformPlugin):
                     pass
 
                 # Combine the various multiplicative corrections to a single correction for S1 and S2
-                ia.s1_area_correction *= ia.s1_spatial_correction * ia.s1_saturation_correction
+                ia.s1_area_correction *= ia.s1_spatial_correction
                 ia.s2_area_correction *= ia.s2_lifetime_correction * s2.s2_spatial_correction
 
                 # Add the saturation correction only if explicitly told (since it's more experimental

--- a/pax/plugins/interaction_processing/BuildInteractions.py
+++ b/pax/plugins/interaction_processing/BuildInteractions.py
@@ -60,7 +60,7 @@ class BasicInteractionProperties(plugin.TransformPlugin):
         self.s1_patterns = self.processor.simulator.s1_patterns
         self.zombie_pmts_s1 = np.array(self.config.get('zombie_pmts_s1', []))
         self.tpc_channels = self.config['channels_in_detector']['tpc']
-        self.do_saturation_correction = self.config.get('active_saturation_and_zombie_correction', False)
+        self.include_saturation_correction = self.config.get('include_saturation_correction', False)
 
     def transform_event(self, event):
 
@@ -82,13 +82,12 @@ class BasicInteractionProperties(plugin.TransformPlugin):
 
                 # Correct for S1 saturation
                 try:
-                    if self.do_saturation_correction:
-                        ia.s1_saturation_correction *= saturation_correction(
-                            peak=s1,
-                            channels_in_pattern=self.tpc_channels,
-                            expected_pattern=self.s1_patterns.expected_pattern((ia.x, ia.y, ia.z)),
-                            confused_channels=confused_s1_channels,
-                            log=self.log)
+                    ia.s1_saturation_correction *= saturation_correction(
+                        peak=s1,
+                        channels_in_pattern=self.tpc_channels,
+                        expected_pattern=self.s1_patterns.expected_pattern((ia.x, ia.y, ia.z)),
+                        confused_channels=confused_s1_channels,
+                        log=self.log)
 
                     # Compute the S1 pattern fit statistic
                     ia.s1_pattern_fit = self.s1_patterns.compute_gof(
@@ -102,9 +101,14 @@ class BasicInteractionProperties(plugin.TransformPlugin):
                     # Do not add any saturation correction, leave pattern fit statistic float('nan')
                     pass
 
-                # Get the full area correction
+                # Combine the various multiplicative corrections to a single correction for S1 and S2
                 ia.s1_area_correction *= ia.s1_spatial_correction * ia.s1_saturation_correction
-                ia.s2_area_correction *= (ia.s2_lifetime_correction *
-                                          s2.s2_spatial_correction *
-                                          s2.s2_saturation_correction)
+                ia.s2_area_correction *= ia.s2_lifetime_correction * s2.s2_spatial_correction
+
+                # Add the saturation correction only if explicitly told (since it's more experimental
+                # than the other ones)
+                if self.include_saturation_correction:
+                    ia.s1_area_correction *= ia.s1_saturation_correction
+                    ia.s2_area_correction *= s2.s2_saturation_correction
+
         return event

--- a/pax/plugins/peak_processing/PeakAreaCorrections.py
+++ b/pax/plugins/peak_processing/PeakAreaCorrections.py
@@ -39,7 +39,6 @@ class S2SaturationCorrection(plugin.TransformPlugin):
     def startup(self):
         self.s2_patterns = self.processor.simulator.s2_patterns
         self.zombie_pmts_s2 = np.array(self.config.get('zombie_pmts_s2', []))
-        self.do_saturation_correction = self.config.get('active_saturation_and_zombie_correction', True)
 
     def transform_event(self, event):
 
@@ -53,17 +52,15 @@ class S2SaturationCorrection(plugin.TransformPlugin):
             except ValueError:
                 self.log.debug("Could not find any position from the chosen algorithms")
                 continue
-            if self.s2_patterns is not None and self.do_saturation_correction:
-                # if self.s2_patterns.expected_pattern((xy.x, xy.y)):
-                try:
-                    peak.s2_saturation_correction *= saturation_correction(
-                        peak=peak,
-                        channels_in_pattern=self.config['channels_top'],
-                        expected_pattern=self.s2_patterns.expected_pattern((xy.x, xy.y)),
-                        confused_channels=np.union1d(peak.saturated_channels, self.zombie_pmts_s2),
-                        log=self.log)
-                except exceptions.CoordinateOutOfRangeException:
-                    self.log.debug("Expected light pattern at coordinates "
-                                   "(%f, %f) consists of only zeros!" % (xy.x, xy.y))
+            try:
+                peak.s2_saturation_correction *= saturation_correction(
+                    peak=peak,
+                    channels_in_pattern=self.config['channels_top'],
+                    expected_pattern=self.s2_patterns.expected_pattern((xy.x, xy.y)),
+                    confused_channels=np.union1d(peak.saturated_channels, self.zombie_pmts_s2),
+                    log=self.log)
+            except exceptions.CoordinateOutOfRangeException:
+                self.log.debug("Expected light pattern at coordinates "
+                               "(%f, %f) consists of only zeros!" % (xy.x, xy.y))
 
         return event


### PR DESCRIPTION
This ensures that the S1 and S2 correction values computed by Sander's saturation correction algorithm (see https://github.com/XENON1T/pax/pull/237) are saved even if we do not include them in the total correction (interaction.s2_area_correction and interaction.s1_area_correction).

We do not currently include the saturation correction for XENON1T since they're a bit more experimental than the other corrections (although they work fine for XENON100, they rely on the Monte Carlo LCE per-PMT map). Hopefully after we see they work well on a couple of datasets we can include them in the total correction, as we do for XENON100. You will always be able to access all individual corrections separately (see https://github.com/XENON1T/pax/pull/322).