### PR TITLE
add S2 correction in task list

### DIFF
--- a/pax/config/XENON1T.ini
+++ b/pax/config/XENON1T.ini
@@ -56,6 +56,7 @@ compute_properties = [
 
                         # Additional properties
                         'HitpatternSpread.HitpatternSpread',
+                        'PeakAreaCorrections.S2SpatialCorrection',
                         'PeakAreaCorrections.S2SaturationCorrection',
                      ]
 


### PR DESCRIPTION
@adambrown1 found that S2 spatial correction has never been calculated in pax. In this update, we include the s2 correction in the processor task list.