### PR TITLE
Add random initial pickle to acquisition monitor file

### DIFF
--- a/pax/plugins/io/MongoDB.py
+++ b/pax/plugins/io/MongoDB.py
@@ -633,6 +633,10 @@ class MongoDBClearUntriggered(plugin.TransformPlugin, MongoBase):
                 self.aqm_module, aqm_file_path))
             self.aqm_output_handle = open(aqm_file_path, mode='wb')
 
+            # Add some random content to make Boris and ruciax happy
+            # (ensure a unique checksum even if there are no pulses or the DAQ crashes)
+            self.aqm_output_handle.write(pickle.dumps("Pax rules! Random numbers of the day: %s" % np.random.randn(3)))
+
         self.already_rescued_collections = []
 
     def transform_event(self, event_proxy):


### PR DESCRIPTION
This addresses #607 by adding some random nonsense at the start of each acquisition monitor pickle file.  There will be a companion pull request in hax to make the acquisition monitor pulse reading code robust to this.