### PR TITLE
Update S2 xy map in SR1 config

### DIFF
--- a/pax/config/SR1_parameters.ini
+++ b/pax/config/SR1_parameters.ini
@@ -21,7 +21,7 @@ drift_field =                         82 * V /cm
 
 # Light distribution
 s1_light_yield_map =                  's1_xyz_XENON1T_kr83m-sr1_pax-664_fdc-adcorrtpf.json'
-s2_light_yield_map =                  's2_xy_map_v2.1.json'
+s2_light_yield_map =                  's2_xy_map_v2.2.json'
 s2_fitted_patterns_file =             'XENON1T_s2_xy_fitted_patterns_top_v0.3.0.json.gz'
 s2_mean_area_fraction_top =           0.627    # See xenon:xenon1t:sim:notes:yuehuan:sr_1_kr83m&#s2_top_fraction
 


### PR DESCRIPTION
Forgot to update S2 xy correction map in ```SR1_parameters.ini``` to v2.2 (as in [hax.ini](https://github.com/XENON1T/hax/blob/v2.3.1/hax/hax.ini#L125) now). This config is mostly used in simulations now, but perhaps we should also use for hax [here](https://github.com/XENON1T/hax/blob/v2.3.1/hax/treemakers/posrec.py#L60) if not defined [there](https://github.com/XENON1T/hax/blob/v2.3.1/hax/hax.ini#L122) already, for example ```s2_patterns_file``` which has changed in ```XENON1T.ini``` since the ```pax_v6.8.0``` reprocessing, and we need to be consistent now for recalculations.