### PR TITLE
Split dependencies into upgradable and not upgradable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
       - libboost-all-dev
       - build-essential
       - libc6-dev
+      - snappy
 
 matrix:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,20 @@ sudo: false
 
 matrix:
     include:
+        - python: 2.7
+          env: PYTHON=2.7 ROOT=5.34.32
         - python: 3.4
           env: PYTHON=3.4 ROOT=5.34.32
+        - python: 2.7
+          env: PYTHON=2.7 ROOT=6.04
         - python: 3.4
           env: PYTHON=3.4 ROOT=6.04
+
+    allow_failures:
+        - python: 2.7
+          env: PYTHON=2.7 ROOT=5.34.32
+        - python: 2.7
+          env: PYTHON=2.7 ROOT=6.04
 
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
 
 
 notifications:
-  #email:
+  email:
     - ctunnell@nikhef.nl
     - jaalbers@nikhef.nl
     - feigao.ge@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
       - libboost-all-dev
       - build-essential
       - libc6-dev
-      - libpthread-stubs0
+      - libpthread-stubs0-dev
       - snappy
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ addons:
     packages:
       - libboost-all-dev
       - build-essential
+      - libc6-dev
 
 matrix:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ matrix:
 
 notifications:
   #email:
-    #- ctunnell@nikhef.nl
-    #- jaalbers@nikhef.nl
-    #- feigao.ge@gmail.com
+    - ctunnell@nikhef.nl
+    - jaalbers@nikhef.nl
+    - feigao.ge@gmail.com
   webhooks:
     urls:
       - https://webhooks.gitter.im/e/09d571df0e21d4d4182f

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 
 language: python
 
+dist: trusty
+
 sudo: false
 
 addons:
@@ -10,6 +12,7 @@ addons:
       - libboost-all-dev
       - build-essential
       - libc6-dev
+      - libpthread-stubs0
       - snappy
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ language: python
 
 sudo: false
 
+addons:
+  apt:
+    packages:
+      - libboost-all-dev
+      - build-essential
+
 matrix:
     include:
         - python: 2.7
@@ -45,7 +51,9 @@ before_script:
           sleep 3; 
       fi
 
-install:
+
+before_install:
+  
   # Conda
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then curl --silent http://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh -o miniconda.sh; fi
   - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then wget -nv http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
@@ -61,10 +69,13 @@ install:
   - conda config --add channels http://conda.anaconda.org/NLeSC  
   - conda create -q -n pax python=${PYTHON} root=${ROOT} numpy scipy h5py pyqt matplotlib pandas cython numba pip python-snappy pytables scikit-learn rootpy psutil jupyter root_pandas
   - source activate pax
+
+install:
   - pip install coveralls nose coverage
 
   # Install pax
   - pip install mongodbproxy    # Somehow needs explicit install?
+  - pip install -r requirements.txt
   - python setup.py install
   - pip freeze
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,13 +3,13 @@ pymongo==3.6.1
 tqdm==4.20.0
 pandas==0.22.0
 flake8==3.5.0
-python-snappy==0.5.2
 mock==2.0.0
 rabbitpy==1.0.0
 multihist==0.5.4
 msgpack-python==0.5.6
 
 # Unupgradable
+python-snappy==0.5.0  # pyup: ignore
 wheel>=0.23.0  # pyup: ignore
 numpy==1.11.3  # pyup: ignore
 matplotlib==2.0.0  # pyup: ignore

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,24 @@
-wheel>=0.23.0
-numpy==1.11.3
+# Upgradable
 pymongo==3.6.1
-matplotlib==2.0.0
-scipy==0.18.1
 tqdm==4.20.0
-prettytable==0.7.2
 pandas==0.22.0
 flake8==3.5.0
 python-snappy==0.5.2
-numba==0.35.0
-scikit-learn==0.18.1
-#h5py==2.6.0
-six==1.10.0
-numexpr==2.6.1
-psutil==5.0.1
 mock==2.0.0
 rabbitpy==1.0.0
 multihist==0.5.4
 msgpack-python==0.5.6
+
+# Unupgradable
+wheel>=0.23.0
+numpy==1.11.3
+matplotlib==2.0.0
+scipy==0.18.1
+prettytable==0.7.2
+numba==0.35.0
+scikit-learn==0.18.1
+#h5py==2.6.0 # See setup.py call
+six==1.10.0
+numexpr==2.6.1
+psutil==5.0.1
 pytz==2017.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,15 +10,15 @@ multihist==0.5.4
 msgpack-python==0.5.6
 
 # Unupgradable
-wheel>=0.23.0
-numpy==1.11.3
-matplotlib==2.0.0
-scipy==0.18.1
-prettytable==0.7.2
-numba==0.35.0
-scikit-learn==0.18.1
-#h5py==2.6.0 # See setup.py call
-six==1.10.0
-numexpr==2.6.1
-psutil==5.0.1
-pytz==2017.2
+wheel>=0.23.0  # pyup: ignore
+numpy==1.11.3  # pyup: ignore
+matplotlib==2.0.0  # pyup: ignore
+scipy==0.18.1  # pyup: ignore
+prettytable==0.7.2  # pyup: ignore
+numba==0.35.0  # pyup: ignore
+scikit-learn==0.18.1  # pyup: ignore
+#h5py==2.6.0  # pyup: ignore
+six==1.10.0  # pyup: ignore
+numexpr==2.6.1  # pyup: ignore
+psutil==5.0.1  # pyup: ignore
+pytz==2017.2  # pyup: ignore

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ requirements = open('requirements.txt').read().splitlines()
 if six.PY2:
     requirements.append('configparser')
 
+# Avoids "KeyError: 'ROOT'" in TravisCI, see PR #250.
 try:
     import ROOT
 except ImportError:


### PR DESCRIPTION
About half of our dependencies cannot have their versions changed without breaking pax.  After testing in my own fork, I've been able to identify which  can be upgrade and which cannot.  The ones that cannot will be marked as ignore with pyup.