### PR TITLE
lowering tight coincidence to 2-fold

### DIFF
--- a/pax/config/XENON1T.ini
+++ b/pax/config/XENON1T.ini
@@ -313,9 +313,6 @@ s2_afterpulse_types = {
 max_gap_size_in_cluster = 3.50 * us
 max_gap_size_in_s1like_cluster = 350 * ns
 
-# s1 width/rist_time bound, in ns
-s1_width_threshold = 300
-s1_risetime_threshold = 70
 
 [NaturalBreaksClustering]
 # Points in log10(peak_area), goodness_of_split. Split threshold is linearly interpolated between these.

--- a/pax/config/XENON1T.ini
+++ b/pax/config/XENON1T.ini
@@ -313,6 +313,9 @@ s2_afterpulse_types = {
 max_gap_size_in_cluster = 3.50 * us
 max_gap_size_in_s1like_cluster = 350 * ns
 
+# s1 width/rist_time bound, in ns
+s1_width_threshold = 300
+s1_risetime_threshold = 70
 
 [NaturalBreaksClustering]
 # Points in log10(peak_area), goodness_of_split. Split threshold is linearly interpolated between these.

--- a/pax/config/_base.ini
+++ b/pax/config/_base.ini
@@ -90,6 +90,10 @@ tight_coincidence_window_left = 50 * ns
 tight_coincidence_window_right = 50 * ns
 # number of coincidence channels inside a short time window. SR0+SR1 SI uses 3-fold coincidence.
 tight_coincidence_threshold = 2
+# s1 width/rist_time bound, in ns
+s1_width_threshold = 300
+s1_risetime_threshold = 70
+
 
 [BuildInteractions.BasicInteractionProperties]
 # Statistic to use for the S1 pattern goodness of fit: same options as for PosRecTopPatternFit

--- a/pax/config/_base.ini
+++ b/pax/config/_base.ini
@@ -90,9 +90,6 @@ tight_coincidence_window_left = 50 * ns
 tight_coincidence_window_right = 50 * ns
 # number of coincidence channels inside a short time window. SR0+SR1 SI uses 3-fold coincidence.
 tight_coincidence_threshold = 2
-# s1 width/rist_time bound, in ns
-s1_width_threshold = 300
-s1_risetime_threshold = 70
 
 
 [BuildInteractions.BasicInteractionProperties]

--- a/pax/config/_base.ini
+++ b/pax/config/_base.ini
@@ -69,7 +69,9 @@ external_amplification = 10
 # This is merely the reference point
 digitizer_reference_baseline = 16000
 
-
+# width & rist_time bound, in ns for s1&s2 classification
+s1_width_threshold = 300
+s1_risetime_threshold = 70
 
 [Queues]
 timeout_after_sec = 300
@@ -90,7 +92,6 @@ tight_coincidence_window_left = 50 * ns
 tight_coincidence_window_right = 50 * ns
 # number of coincidence channels inside a short time window. SR0+SR1 SI uses 3-fold coincidence.
 tight_coincidence_threshold = 2
-
 
 [BuildInteractions.BasicInteractionProperties]
 # Statistic to use for the S1 pattern goodness of fit: same options as for PosRecTopPatternFit

--- a/pax/config/_base.ini
+++ b/pax/config/_base.ini
@@ -88,6 +88,8 @@ subtract_reference_baseline_only_for_raw_waveform = False
 # Must be an odd number of digitizer samples (otherwise will be slightly wider than you specify)
 tight_coincidence_window_left = 50 * ns
 tight_coincidence_window_right = 50 * ns
+# number of coincidence channels inside a short time window. SR0+SR1 SI uses 3-fold coincidence.
+tight_coincidence_threshold = 2
 
 [BuildInteractions.BasicInteractionProperties]
 # Statistic to use for the S1 pattern goodness of fit: same options as for PosRecTopPatternFit
@@ -97,7 +99,6 @@ s1_pattern_statistic = 'likelihood_poisson'
 # If false, the saturation corrections will still be computed, but it will not be taken into account in the final
 # total correction.
 include_saturation_correction = False
-
 
 ##
 # Trigger default settings (maybe these should be in XENON1T.ini... but it's nice to try them on XENON100 data too)

--- a/pax/config/_base.ini
+++ b/pax/config/_base.ini
@@ -73,6 +73,13 @@ digitizer_reference_baseline = 16000
 s1_width_threshold = 300
 s1_risetime_threshold = 70
 
+# Window within which hit maxima can count towards the tight coincidence level.
+# Must be an odd number of digitizer samples (otherwise will be slightly wider than you specify)
+tight_coincidence_window_left = 50 * ns
+tight_coincidence_window_right = 50 * ns
+# number of coincidence channels inside a short time window. SR0+SR1 SI uses 3-fold coincidence.
+tight_coincidence_threshold = 2
+
 [Queues]
 timeout_after_sec = 300
 
@@ -86,12 +93,6 @@ subtract_reference_baseline_only_for_raw_waveform = False
 
 
 [BasicProperties.SumWaveformProperties]
-# Window within which hit maxima can count towards the tight coincidence level.
-# Must be an odd number of digitizer samples (otherwise will be slightly wider than you specify)
-tight_coincidence_window_left = 50 * ns
-tight_coincidence_window_right = 50 * ns
-# number of coincidence channels inside a short time window. SR0+SR1 SI uses 3-fold coincidence.
-tight_coincidence_threshold = 2
 
 [BuildInteractions.BasicInteractionProperties]
 # Statistic to use for the S1 pattern goodness of fit: same options as for PosRecTopPatternFit

--- a/pax/plugins/peak_processing/ClassifyPeaks.py
+++ b/pax/plugins/peak_processing/ClassifyPeaks.py
@@ -6,7 +6,7 @@ class AdHocClassification1T(plugin.TransformPlugin):
 
     def startup(self):
         self.s1_rise_time_bound = interpolate.interp1d([0, 5, 10, 100],
-                                                       [80, 75, 70, 70],
+                                                       [70, 70, 70, 70],
                                                        fill_value='extrapolate', kind='linear')
         self.s1_rise_time_aft = interpolate.interp1d([0, 0.4, 0.5, 0.6, 0.70, 0.70, 1.0],
                                                      [70, 70, 68, 65, 60, 0, 0], kind='linear')
@@ -25,12 +25,13 @@ class AdHocClassification1T(plugin.TransformPlugin):
                 peak.area_fraction_top = 1
 
             # classification based on rise_time and aft
-            if -peak.area_decile_from_midpoint[1] < self.s1_rise_time_bound(peak.area):
-                # Peak rises fast, could be S1
+            if -peak.area_decile_from_midpoint[1] < self.s1_rise_time_bound(peak.area)\
+                    and peak.range_area_decile[9] < 300:
+                # S1 requirements: Peak rises fast, and width (90p area) small
                 if peak.tight_coincidence < self.tight_coincidence_threshold:
                     # Too few PMTs contributing, hard to distinguish from junk
                     peak.type = 'unknown'
-                elif peak.area > 100 or peak.area < 5:
+                elif peak.area > 100:
                     # Apply single electron s2 cut only in 5 - 100 PE range, otherwise only rely on rise time
                     peak.type = 's1'
                 elif -peak.area_decile_from_midpoint[1] < self.s1_rise_time_aft(peak.area_fraction_top):

--- a/pax/plugins/peak_processing/ClassifyPeaks.py
+++ b/pax/plugins/peak_processing/ClassifyPeaks.py
@@ -10,6 +10,7 @@ class AdHocClassification1T(plugin.TransformPlugin):
                                                        fill_value='extrapolate', kind='linear')
         self.s1_rise_time_aft = interpolate.interp1d([0, 0.4, 0.5, 0.6, 0.70, 0.70, 1.0],
                                                      [70, 70, 68, 65, 60, 0, 0], kind='linear')
+        self.tight_coincidence_threshold = self.config['tight_coincidence_threshold']
 
     def transform_event(self, event):
 
@@ -26,7 +27,7 @@ class AdHocClassification1T(plugin.TransformPlugin):
             # classification based on rise_time and aft
             if -peak.area_decile_from_midpoint[1] < self.s1_rise_time_bound(peak.area):
                 # Peak rises fast, could be S1
-                if peak.tight_coincidence <= 2:
+                if peak.tight_coincidence < self.tight_coincidence_threshold:
                     # Too few PMTs contributing, hard to distinguish from junk
                     peak.type = 'unknown'
                 elif peak.area > 100 or peak.area < 5:

--- a/pax/plugins/peak_processing/ClassifyPeaks.py
+++ b/pax/plugins/peak_processing/ClassifyPeaks.py
@@ -8,8 +8,7 @@ class AdHocClassification1T(plugin.TransformPlugin):
         self.s1_rise_time_bound = interpolate.interp1d([0, 5, 10, 100],
                                                        [70, 70, 70, 70],
                                                        fill_value='extrapolate', kind='linear')
-        self.s1_rise_time_aft = interpolate.interp1d([0, 0.4, 0.5, 0.6, 0.70, 0.70, 1.0],
-                                                     [70, 70, 68, 65, 60, 0, 0], kind='linear')
+
         self.tight_coincidence_threshold = self.config['tight_coincidence_threshold']
 
     def transform_event(self, event):
@@ -31,14 +30,8 @@ class AdHocClassification1T(plugin.TransformPlugin):
                 if peak.tight_coincidence < self.tight_coincidence_threshold:
                     # Too few PMTs contributing, hard to distinguish from junk
                     peak.type = 'unknown'
-                elif peak.area > 100:
-                    # Apply single electron s2 cut only in 5 - 100 PE range, otherwise only rely on rise time
-                    peak.type = 's1'
-                elif -peak.area_decile_from_midpoint[1] < self.s1_rise_time_aft(peak.area_fraction_top):
-                    # Rise time and AFT as multi-dimensional discriminator
-                    peak.type = 's1'
                 else:
-                    peak.type = 's2'
+                    peak.type = 's1'
             else:
                 # No fast rise
                 if peak.n_contributing_channels > 4:

--- a/pax/plugins/signal_processing/BuildPeaks.py
+++ b/pax/plugins/signal_processing/BuildPeaks.py
@@ -1,5 +1,4 @@
 import numpy as np
-from scipy import interpolate
 from pax import plugin, dsputils
 from pax.plugins.peak_processing.BasicProperties import integrate_until_fraction
 
@@ -20,16 +19,8 @@ class GapSizeClustering(plugin.ClusteringPlugin):
         self.gap_threshold = self.config['max_gap_size_in_cluster'] / self.dt
 
         # Rise time bound
-        self.s1_rise_time_bound = interpolate.interp1d([0, 5, 10, 100],
-                                                       [80, 75, 70, 70],
-                                                       fill_value='extrapolate', kind='linear')
-
-        # Rise time vs AFT cut
-        self.s1_rise_time_aft = interpolate.interp1d([0, 0.4, 0.5, 0.6, 0.70, 0.70, 1.0],
-                                                     [70, 70, 68, 65, 60, 0, 0], kind='linear')
-
-        self.first_top_ch = np.min(np.array(self.config['channels_top']))
-        self.last_top_ch = np.max(np.array(self.config['channels_top']))
+        self.s1_rise_time_bound = 70  # 70ns as rise_time cut
+        self.s1_width_bound = 300  # 300 ns as width cut
 
     @staticmethod
     def iterate_gap_clusters(hits, gap_threshold):
@@ -53,7 +44,6 @@ class GapSizeClustering(plugin.ClusteringPlugin):
             # First cluster into small clusters. Try to find S1 candidates among them, and set these apart
             s1_mask = np.zeros(len(hits), dtype=np.bool)    # True if hit is part of S1 candidate
             for l_i, r_i, h in self.iterate_gap_clusters(hits, self.s1_gap_threshold):
-                area_sum = np.sum(h['area'])
                 peak = self.build_peak(hits=h, detector=detector)
                 # use summed WF to calculate peak properties
                 w = event.get_sum_waveform(peak.detector).samples[peak.left:peak.right + 1]
@@ -64,24 +54,14 @@ class GapSizeClustering(plugin.ClusteringPlugin):
                 integrate_until_fraction(w, fractions_desired=np.linspace(0, 1, 21), results=area_times)
                 area_times *= dt
                 area_midpoint = area_times[10]
+                # rise time
                 area_decile_from_midpoint = area_times[::2] - area_midpoint
                 rise_time = -area_decile_from_midpoint[1]
+                # width
+                range_area_decile = area_times[10:] - area_times[10::-1]
 
-                # Area fraction on top
-                peak.area_fraction_top =\
-                    np.sum(peak.area_per_channel[self.first_top_ch:self.last_top_ch + 1]) / peak.area
-                # rounding peak aft
-                if peak.area_fraction_top < 0:
-                    peak.area_fraction_top = 0
-                elif peak.area_fraction_top > 1:
-                    peak.area_fraction_top = 1
-
-                rise_time_cut = self.s1_rise_time_aft(peak.area_fraction_top)
-                # If area is large enough, change to a looser threshold
-                if peak.area > 100 or peak.area < 5:
-                    rise_time_cut = self.s1_rise_time_bound(peak.area)
-                coincidence = peak.n_contributing_channels
-                if rise_time < rise_time_cut or coincidence <= 4 or area_sum < 5:
+                if (rise_time < self.s1_rise_time_bound and range_area_decile[9] < self.s1_width_bound)\
+                        or peak.n_contributing_channels < 4:
                     # Yes, this is an S1 candidate Or, this is a lone hit. Mark it as a peak,
                     # hits will be ignored in next stage.
                     s1_mask[l_i:r_i] = True

--- a/pax/plugins/signal_processing/BuildPeaks.py
+++ b/pax/plugins/signal_processing/BuildPeaks.py
@@ -19,8 +19,8 @@ class GapSizeClustering(plugin.ClusteringPlugin):
         self.gap_threshold = self.config['max_gap_size_in_cluster'] / self.dt
 
         # Rise time bound
-        self.s1_rise_time_bound = 70  # 70ns as rise_time cut
-        self.s1_width_bound = 300  # 300 ns as width cut
+        self.s1_rise_time_bound = self.config['s1_risetime_threshold']  # 70ns as rise_time cut
+        self.s1_width_bound = self.config['s1_width_threshold']  # 300 ns as width cut
 
     @staticmethod
     def iterate_gap_clusters(hits, gap_threshold):


### PR DESCRIPTION
This PR lowers the tight coincidence coincidence to two-fold in order to improve the acceptance of low-E events, as requested by @mcfatelin 

I also included a S1width (range_90p_area) in the classification, which should replace the [S1Width cut in LAX](https://github.com/XENON1T/lax/blob/master/lax/lichens/sciencerun0.py#L577).