### PR TITLE
Push Git tag before actual commits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,34 +62,34 @@ major: clean docs
 	vim HISTORY.rst
 	git commit -m "Update HISTORY for the release" HISTORY.rst
 	bumpversion major
-	git push
 	git push --tags
+	git push
 	git checkout stable
 	git merge master
-	git push
 	git push --tags
+	git push
 	git checkout master
 
 minor: clean docs
 	vim HISTORY.rst
 	git commit -m "Update HISTORY for the release" HISTORY.rst
 	bumpversion minor
-	git push
 	git push --tags
+	git push
 	git checkout stable
 	git merge master
-	git push
 	git push --tags
+	git push
 	git checkout master
 
 patch: clean docs
 	vim HISTORY.rst
 	git commit -m "Update HISTORY for the release" HISTORY.rst
 	bumpversion patch
-	git push
 	git push --tags
+	git push
 	git checkout stable
 	git merge master
-	git push
 	git push --tags
+	git push
 	git checkout master


### PR DESCRIPTION
Noticed some weird behavior with deployHQ where new release environment was not being created on CVMFS. Hypothesis: Do ```git push --tag``` before actual commits so DeployHQ knows about the new tag in order to build new Anaconda environment. Not sure if it'll work (can test at next release), but it shouldn't break the workflow, right @tunnell?