### PR TITLE
Segregate hit smoothing

### DIFF
--- a/pax/plugins/ZLE.py
+++ b/pax/plugins/ZLE.py
@@ -52,7 +52,8 @@ class SoftwareZLE(plugin.TransformPlugin):
                 threshold = self.config['zle_threshold'] + 1
 
             # Find intervals above ZLE threshold
-            n_itvs_found = find_intervals_above_threshold(w.astype(np.float64),
+            # We need to call the version with numba boost
+            n_itvs_found = find_intervals_above_threshold_no_splitting(w.astype(np.float64),
                                                           threshold=threshold,
                                                           result_buffer=zle_intervals_buffer,
                                                           )

--- a/pax/plugins/ZLE.py
+++ b/pax/plugins/ZLE.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from pax import plugin, datastructure
 
-from pax.dsputils import find_intervals_above_threshold
+from pax.dsputils import find_intervals_above_threshold_no_splitting
 
 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
#712 included the addition of additional [smoothing and splitting](https://github.com/XENON1T/pax/pull/712/files#diff-5d2794434093c23639c8c8f1e5044cb2R203) when `find_intervals_above_threshold()` is called in the hitfinder. This added some numpy functions, which necessitated the removal of the numba speed boosting. This function is also caused during the ZLE phase of [fax](https://github.com/XENON1T/pax/blob/master/pax/plugins/ZLE.py#L55), which has since slowed down significantly. Unfortunately, since the numba boosting couldn't work on the current function, I didn't see a fix besides duplicating a good amount of code 🤷‍♂️ . In this PR, the old version of the function is instead called in `ZLE.py`, restoring fax's speed.